### PR TITLE
PCI-1202 Enable Dependabot to parse both Dockerfile and Concourse pipeline template files

### DIFF
--- a/docker/spec/dependabot/docker/file_fetcher_spec.rb
+++ b/docker/spec/dependabot/docker/file_fetcher_spec.rb
@@ -168,6 +168,7 @@ RSpec.describe Dependabot::Docker::FileFetcher do
   context "with a yml template", :pix4d do
     let(:file_fixture) { fixture("github", "contents_pipeline.json") }
 
+    it_behaves_like "a dependency file fetcher"
     before do
       stub_request(:get, url + "?ref=sha").
         with(headers: token).
@@ -203,6 +204,7 @@ RSpec.describe Dependabot::Docker::FileFetcher do
   end
 
   context "with multiple template files", :pix4d do
+    it_behaves_like "a dependency file fetcher"
     before do
       stub_request(:get, url + "?ref=sha")
         .with(headers: token)
@@ -248,6 +250,7 @@ RSpec.describe Dependabot::Docker::FileFetcher do
   end
 
   context "with a custom named template file", :pix4d do
+    it_behaves_like "a dependency file fetcher"
     before do
       stub_request(:get, url + "?ref=sha")
         .with(headers: token)
@@ -274,6 +277,7 @@ RSpec.describe Dependabot::Docker::FileFetcher do
   end
 
   context "with a directory that does not exist", :pix4d do
+    it_behaves_like "a dependency file fetcher"
     let(:directory) { "/non/existant" }
 
     before do
@@ -293,6 +297,7 @@ RSpec.describe Dependabot::Docker::FileFetcher do
   end
 
   context "with a docker-image-version file", :pix4d do
+    it_behaves_like "a dependency file fetcher"
     before do
       stub_request(:get, url + "?ref=sha")
         .with(headers: token)

--- a/docker/spec/dependabot/docker/file_parser_spec.rb
+++ b/docker/spec/dependabot/docker/file_parser_spec.rb
@@ -636,17 +636,22 @@ RSpec.describe Dependabot::Docker::FileParser do
       end
     end
 
-    let(:dockerfile) do
-      Dependabot::DependencyFile.new(name: file_name, content: file_body)
-    end
-
     context "single yml file which contains no registry-image resources", :pix4d do
+      it_behaves_like "a dependency file parser"
       let(:file_name) { "no-registry.yml" }
+      let(:dockerfile) do
+        Dependabot::DependencyFile.new(name: "#{file_name}-template", content: file_body)
+      end
       it "to be empty" do
         expect(dependencies).to be_empty
       end
     end
+
     context "single yml file which contains a single resource", :pix4d do
+      it_behaves_like "a dependency file parser"
+      let(:dockerfile) do
+        Dependabot::DependencyFile.new(name: "#{file_name}-template", content: file_body)
+      end
       describe "with a simple public repository name" do
         let(:file_name) { "public-simple.yml" }
         subject(:dependency) { dependencies.first }
@@ -654,7 +659,7 @@ RSpec.describe Dependabot::Docker::FileParser do
           [{
             requirement: nil,
             groups: [],
-            file: file_name,
+            file: "#{file_name}-template",
             source: { tag: "1.0.7" }
           }]
         end
@@ -673,7 +678,7 @@ RSpec.describe Dependabot::Docker::FileParser do
           [{
             requirement: nil,
             groups: [],
-            file: file_name,
+            file: "#{file_name}-template",
             source: { tag: "3.7.1" }
           }]
         end
@@ -692,7 +697,7 @@ RSpec.describe Dependabot::Docker::FileParser do
           [{
             requirement: nil,
             groups: [],
-            file: file_name,
+            file: "#{file_name}-template",
             source: { registry: "private.repo.com", tag: "20190620" }
           }]
         end
@@ -710,7 +715,7 @@ RSpec.describe Dependabot::Docker::FileParser do
           [{
             requirement: nil,
             groups: [],
-            file: file_name,
+            file: "#{file_name}-template",
             source: { registry: "private.repo.com", tag: "20190620150000" }
           }]
         end
@@ -723,7 +728,11 @@ RSpec.describe Dependabot::Docker::FileParser do
     end # context
 
     context "single yml file which contains multiple (two) public resources", :pix4d do
+      it_behaves_like "a dependency file parser"
       let(:file_name) { "public-mix.yml" }
+      let(:dockerfile) do
+        Dependabot::DependencyFile.new(name: "#{file_name}-template", content: file_body)
+      end
 
       describe "having a resource with single part repository name" do
         subject(:dependency) { dependencies.first }
@@ -731,7 +740,7 @@ RSpec.describe Dependabot::Docker::FileParser do
           [{
             requirement: nil,
             groups: [],
-            file: file_name,
+            file: "#{file_name}-template",
             source: { tag: "1.0.7" }
           }]
         end
@@ -748,7 +757,7 @@ RSpec.describe Dependabot::Docker::FileParser do
           [{
             requirement: nil,
             groups: [],
-            file: file_name,
+            file: "#{file_name}-template",
             source: { tag: "3.7.1" }
           }]
         end
@@ -761,7 +770,11 @@ RSpec.describe Dependabot::Docker::FileParser do
     end # context
 
     context "single yml file which contains multiple resources (mix of private and public ones)", :pix4d do
+      it_behaves_like "a dependency file parser"
       let(:file_name) { "mix.yml" }
+      let(:dockerfile) do
+        Dependabot::DependencyFile.new(name: "#{file_name}-template", content: file_body)
+      end
 
       describe "having a resource with single part repository name" do
         subject(:dependency) { dependencies.first }
@@ -769,7 +782,7 @@ RSpec.describe Dependabot::Docker::FileParser do
           [{
             requirement: nil,
             groups: [],
-            file: file_name,
+            file: "#{file_name}-template",
             source: { tag: "1.0.7" }
           }]
         end
@@ -786,7 +799,7 @@ RSpec.describe Dependabot::Docker::FileParser do
           [{
             requirement: nil,
             groups: [],
-            file: file_name,
+            file: "#{file_name}-template",
             source: { tag: "3.7.1" }
           }]
         end
@@ -803,7 +816,7 @@ RSpec.describe Dependabot::Docker::FileParser do
           [{
             requirement: nil,
             groups: [],
-            file: file_name,
+            file: "#{file_name}-template",
             source: { registry: "private.repo.com", tag: "20190620" }
           }]
         end
@@ -820,7 +833,7 @@ RSpec.describe Dependabot::Docker::FileParser do
           [{
             requirement: nil,
             groups: [],
-            file: file_name,
+            file: "#{file_name}-template",
             source: { registry: "private.repo.com", tag: "20190620150000" }
           }]
         end

--- a/docker/spec/dependabot/docker/file_updater_spec.rb
+++ b/docker/spec/dependabot/docker/file_updater_spec.rb
@@ -434,122 +434,124 @@ RSpec.describe Dependabot::Docker::FileUpdater do
         end
       end
     end
+  describe "#updated_dependency_files",:pix4d do
+    it_behaves_like "a dependency file updater"
 
-  it "raises the correct error when there is no input files or the files are not a list", :pix4d do
-    expect do
-      described_class.new(
-        dependencies: nil,
-        dependency_files: [nil],
+    it "raises the correct error when 'dependency_files' do not contain any files or when 'dependency_files' is not a list" do
+      expect do
+        described_class.new(
+          dependencies: nil,
+          dependency_files: [nil],
+          credentials: nil
+        )
+      end .to raise_error("No file!")
+
+      expect do
+        described_class.new(
+          dependencies: nil,
+          dependency_files: nil,
+          credentials: nil
+        )
+      end .to raise_error("undefined method `any?' for nil:NilClass")
+    end
+
+    it "updates the input files"  do
+      # expected output
+      expected_requirements =
+        [{
+          requirement: nil,
+          groups: [],
+          file: "public-simple.yml",
+          source: { tag: "1.10" }
+        }]
+
+      previous_requirements =
+        [{
+          requirement: nil,
+          groups: [],
+          file: "public-simple.yml",
+          source: { tag: "1.0.7" }
+        }]
+
+      # required input for the FileUpdater class
+      input_files = Dependabot::DependencyFile.new(
+        name: "public-simple.yml",
+        content: fixture("pipelines", "public-simple.yml")
+      )
+
+      input_dependencies = Dependabot::Dependency.new(
+        name: "public-image-name-1",
+        version: "1.10",
+        previous_version: "1.0.7",
+        requirements: expected_requirements,
+        previous_requirements: previous_requirements,
+        package_manager: "docker"
+      )
+
+      # call and instance to the FileUpdater class
+      updater = described_class.new(
+        dependencies: [input_dependencies],
+        dependency_files: [input_files],
         credentials: nil
       )
-    end .to raise_error("No file!")
 
-    expect do
-      described_class.new(
-        dependencies: nil,
-        dependency_files: nil,
-        credentials: nil
-      )
-    end .to raise_error("undefined method `any?' for nil:NilClass")
-  end
-
-  it "creates the input objects that are needed and update the input files", :pix4d  do
-    # expected output
-    expected_requirements =
-      [{
-        requirement: nil,
-        groups: [],
-        file: "public-simple.yml",
-        source: { tag: "1.10" }
-      }]
-
-    previous_requirements =
-      [{
-        requirement: nil,
-        groups: [],
-        file: "public-simple.yml",
-        source: { tag: "1.0.7" }
-      }]
-
-    # required input for the FileUpdater class
-    input_files = Dependabot::DependencyFile.new(
-      name: "public-simple.yml",
-      content: fixture("pipelines", "public-simple.yml")
-    )
-
-    input_dependencies = Dependabot::Dependency.new(
-      name: "public-image-name-1",
-      version: "1.10",
-      previous_version: "1.0.7",
-      requirements: expected_requirements,
-      previous_requirements: previous_requirements,
-      package_manager: "docker"
-    )
-
-    # call and instance to the FileUpdater class
-    updater = described_class.new(
-      dependencies: [input_dependencies],
-      dependency_files: [input_files],
-      credentials: nil
-    )
-
-    updated_files = updater.updated_dependency_files
-    updated_files.each { |f| expect(f).to be_a(Dependabot::DependencyFile) }
-    expect(updated_files.first.name).to eq("public-simple.yml")
-    expect(updated_files.first.content).to include "public-image-name-1\n"
-    expect(updated_files.first.content).to include "tag: \"1.10\"\n"
-  end
-
-  it "correctly updates the input files if we use the same number/string
-      in both the repository and tag", :pix4d  do
-    # expected output
-    expected_requirements =
-      [{
-        requirement: nil,
-        groups: [],
-        file: "private-complex.yml",
-        source: { tag: "20190825" }
-      }]
-
-    previous_requirements =
-      [{
-        requirement: nil,
-        groups: [],
-        file: "private-complex.yml",
-        source: { tag: "0" }
-      }]
-
-    # required input for the FileUpdater class
-    input_files = Dependabot::DependencyFile.new(
-      name: "private-complex.yml",
-      content: fixture("pipelines", "private-complex.yml")
-    )
-
-    input_dependencies = Dependabot::Dependency.new(
-      name: "private.repo.com/private-image-name-16.04",
-      version: "20190825",
-      previous_version: 0,
-      requirements: expected_requirements,
-      previous_requirements: previous_requirements,
-      package_manager: "docker"
-    )
-
-    # call and instance to the FileUpdater class
-    updater = described_class.new(
-      dependencies: [input_dependencies],
-      dependency_files: [input_files],
-      credentials: nil
-    )
-
-    updated_files = updater.updated_dependency_files
-    updated_files.each { |f| expect(f).to be_a(Dependabot::DependencyFile) }
-    expect(updated_files.first.name).to eq("private-complex.yml")
-    expect(updated_files.first.content).to include "private-image-name-16.04\n"
-    expect(updated_files.first.content).to include "tag: \"20190825\"\n"
+      updated_files = updater.updated_dependency_files
+      updated_files.each { |f| expect(f).to be_a(Dependabot::DependencyFile) }
+      expect(updated_files.first.name).to eq("public-simple.yml")
+      expect(updated_files.first.content).to include "public-image-name-1\n"
+      expect(updated_files.first.content).to include "tag: 1.10\n"
     end
 
     it "correctly updates the input files if we use the same number/string
-        in both the repository and tag (new tag format)", :pix4d  do
+        in both the repository and tag"  do
+      # expected output
+      expected_requirements =
+        [{
+          requirement: nil,
+          groups: [],
+          file: "private-complex.yml",
+          source: { tag: "20190825" }
+        }]
+
+      previous_requirements =
+        [{
+          requirement: nil,
+          groups: [],
+          file: "private-complex.yml",
+          source: { tag: "0" }
+        }]
+
+      # required input for the FileUpdater class
+      input_files = Dependabot::DependencyFile.new(
+        name: "private-complex.yml",
+        content: fixture("pipelines", "private-complex.yml")
+      )
+
+      input_dependencies = Dependabot::Dependency.new(
+        name: "private.repo.com/private-image-name-16.04",
+        version: "20190825",
+        previous_version: 0,
+        requirements: expected_requirements,
+        previous_requirements: previous_requirements,
+        package_manager: "docker"
+      )
+
+      # call and instance to the FileUpdater class
+      updater = described_class.new(
+        dependencies: [input_dependencies],
+        dependency_files: [input_files],
+        credentials: nil
+      )
+
+      updated_files = updater.updated_dependency_files
+      updated_files.each { |f| expect(f).to be_a(Dependabot::DependencyFile) }
+      expect(updated_files.first.name).to eq("private-complex.yml")
+      expect(updated_files.first.content).to include "private-image-name-16.04\n"
+      expect(updated_files.first.content).to include "tag: 20190825\n"
+    end
+
+    it "correctly updates the input files if we use the same number/string
+        in both the repository and tag (new tag format)"  do
 
       expected_requirements =
         [{
@@ -578,7 +580,7 @@ RSpec.describe Dependabot::Docker::FileUpdater do
         previous_version: 0,
         requirements: expected_requirements,
         previous_requirements: expected_previous_requirements,
-        package_manager: "concourse"
+        package_manager: "docker"
       )
 
       updater = described_class.new(
@@ -591,7 +593,142 @@ RSpec.describe Dependabot::Docker::FileUpdater do
       updated_files.each { |f| expect(f).to be_a(Dependabot::DependencyFile) }
       expect(updated_files.first.name).to eq("private-complex.yml")
       expect(updated_files.first.content).to include "private-image-name-16.04\n"
-      expect(updated_files.first.content).to include "tag: \"20190825090000\"\n"
+      expect(updated_files.first.content).to include "tag: 20190825090000\n"
     end
-  end # describe updated_dependency_files
+
+    it "correctly updates the input files if we use the bootstrapme tags"  do
+
+      expected_requirements =
+        [{
+          requirement: nil,
+          groups: [],
+          file: "pix4d-special.yml",
+          source: { tag: "20200308093045" }
+        }]
+
+      expected_previous_requirements =
+        [{
+          requirement: nil,
+          groups: [],
+          file: "pix4d-special.yml",
+          source: { tag: "bootstrapme" }
+        }]
+
+      input_files = Dependabot::DependencyFile.new(
+        name: "pix4d-special.yml",
+        content: fixture("pipelines", "pix4d-special.yml")
+      )
+
+      input_dependencies = Dependabot::Dependency.new(
+        name: "private.repo.com/private-image-name-16.04",
+        version: "20200308093045",
+        previous_version: "bootstrapme",
+        requirements: expected_requirements,
+        previous_requirements: expected_previous_requirements,
+        package_manager: "docker"
+      )
+
+      updater = described_class.new(
+        dependencies: [input_dependencies],
+        dependency_files: [input_files],
+        credentials: nil
+      )
+
+      updated_files = updater.updated_dependency_files
+      updated_files.each { |f| expect(f).to be_a(Dependabot::DependencyFile) }
+      expect(updated_files.first.name).to eq("pix4d-special.yml")
+      expect(updated_files.first.content).to include "private-image-name-16.04\n"
+      expect(updated_files.first.content).to include "tag: 20200308093045\n"
+  end
+
+  it "correctly updates the input files if we use double quotes around tags"  do
+
+    expected_requirements =
+      [{
+        requirement: nil,
+        groups: [],
+        file: "pix4d-special.yml",
+        source: { tag: "20200309103030" }
+      }]
+
+    expected_previous_requirements =
+      [{
+        requirement: nil,
+        groups: [],
+        file: "pix4d-special.yml",
+        source: { tag: "20200220151020" }
+      }]
+
+    input_files = Dependabot::DependencyFile.new(
+      name: "pix4d-special.yml",
+      content: fixture("pipelines", "pix4d-special.yml")
+    )
+
+    input_dependencies = Dependabot::Dependency.new(
+      name: "private.repo.com/private-image-name-18.04",
+      version: "20200309103030",
+      previous_version: "20200220151020",
+      requirements: expected_requirements,
+      previous_requirements: expected_previous_requirements,
+      package_manager: "docker"
+    )
+    updater = described_class.new(
+      dependencies: [input_dependencies],
+      dependency_files: [input_files],
+      credentials: nil
+    )
+
+    updated_files = updater.updated_dependency_files
+    updated_files.each { |f| expect(f).to be_a(Dependabot::DependencyFile) }
+    expect(updated_files.first.name).to eq("pix4d-special.yml")
+    expect(updated_files.first.content).to include "private-image-name-18.04\n"
+    expect(updated_files.first.content).to include "tag: 20200309103030\n"
+  end
+
+  it "correctly updates the input files if we use the bootstrapme tags with double quotes"  do
+
+    expected_requirements =
+      [{
+        requirement: nil,
+        groups: [],
+        file: "pix4d-special.yml",
+        source: { tag: "20200306093045" }
+      }]
+
+    expected_previous_requirements =
+      [{
+        requirement: nil,
+        groups: [],
+        file: "pix4d-special.yml",
+        source: { tag: "bootstrapme" }
+      }]
+
+    input_files = Dependabot::DependencyFile.new(
+      name: "pix4d-special.yml",
+      content: fixture("pipelines", "pix4d-special.yml")
+    )
+
+    input_dependencies = Dependabot::Dependency.new(
+      name: "private.repo.com/private-image-name",
+      version: "20200306093045",
+      previous_version: "bootstrapme",
+      requirements: expected_requirements,
+      previous_requirements: expected_previous_requirements,
+      package_manager: "docker"
+    )
+
+    updater = described_class.new(
+      dependencies: [input_dependencies],
+      dependency_files: [input_files],
+      credentials: nil
+    )
+
+    updated_files = updater.updated_dependency_files
+    updated_files.each { |f| expect(f).to be_a(Dependabot::DependencyFile) }
+    expect(updated_files.first.name).to eq("pix4d-special.yml")
+    expect(updated_files.first.content).to include "private-image-name\n"
+    expect(updated_files.first.content).to include "tag: 20200306093045\n"
+end
+end
+end# describe updated_dependency_files
 end # RSpec.describe

--- a/docker/spec/dependabot/docker/update_checker_spec.rb
+++ b/docker/spec/dependabot/docker/update_checker_spec.rb
@@ -632,690 +632,167 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
     end
   end
 
-  describe "Method #up_to_date?", :pix4d  do
-    before do
-      stub_request(:get, "https://registry.hub.docker.com/v2/library/#{dependency_name}/tags/list")
-        .and_return(
-          status: 200,
-          body: { "name": "library/#{dependency_name}", "tags": ["20171025.8"] }.to_json
-        )
-    end
-    subject { checker.up_to_date? }
-    let(:dependency_name) { "docker-img-name-1" }
-
-    context "given an string dependency tag" do
-      let(:version) { "any_other_string" }
-      it { is_expected.to be_truthy }
-    end
-
-    context "given an bootstrapme dependency tag" do
-      let(:version) { "bootstrapme" }
-      it { is_expected.to be_falsey }
-    end
-
-    context "given an outdated dependency" do
-      let(:version) { "20150620" }
-      it { is_expected.to be_falsey }
-    end
-
-    context "given an outdated dependency" do
-      let(:version) { "20160620.1" }
-      it { is_expected.to be_falsey }
-    end
-
-    context "given an up-to-date dependency" do
-      let(:version) { "20171025.8" }
-      it { is_expected.to be_truthy }
-    end
-  end
-
-  describe "Method #can_update?", :pix4d  do
-    before do
-      stub_request(:get, "https://registry.hub.docker.com/v2/library/#{dependency_name}/tags/list")
-        .and_return(
-          status: 200,
-          body: { "name": "library/#{dependency_name}", "tags": ["20191025.3"] }.to_json
-        )
-    end
-
-    subject { checker.can_update?(requirements_to_unlock: :own) }
-
-    let(:dependency_name) { "docker-img-name-2" }
-
-    context "given an string dependency tag" do
-      let(:version) { "any_other_string" }
-      it { is_expected.to be_falsey }
-    end
-
-    context "given an bootstrapme dependency tag" do
-      let(:version) { "bootstrapme" }
-      it { is_expected.to be_truthy }
-    end
-
-    context "given an outdated dependency" do
-      let(:version) { "20190620" }
-      it { is_expected.to be_truthy }
-    end
-
-    context "given an outdated dependency" do
-      let(:version) { "20190620.1" }
-      it { is_expected.to be_truthy }
-    end
-
-    context "given an outdated dependency" do
-      let(:version) { "20190707" }
-      it { is_expected.to be_truthy }
-    end
-
-    context "given an outdated dependency" do
-      let(:version) { "20190707.1" }
-      it { is_expected.to be_truthy }
-    end
-
-    context "given an up-to-date dependency" do
-      let(:version) { "20191025.3" }
-      it { is_expected.to be_falsey }
-    end
-  end
-
-  describe "Method #latest_version", :pix4d  do
-    subject { checker.latest_version }
-
-    let(:version) { "0" }
-    let(:dependency_name) { "docker-img-name-2" }
-
-    context "return latest tag" do
+  describe "Pix4D tests", :pix4d  do
+    describe "Method #can_update?" do
       before do
         stub_request(:get, "https://registry.hub.docker.com/v2/library/#{dependency_name}/tags/list")
           .and_return(
             status: 200,
-            body: { "name": "library/#{dependency_name}", "tags": ["20191025.3"] }.to_json
+            body: { "name": "library/#{dependency_name}", "tags": ["20200310162045"] }.to_json
           )
       end
 
-      it { is_expected.to eq("20191025.3") }
+      subject { checker.can_update?(requirements_to_unlock: :own) }
+
+      let(:dependency_name) { "docker-img-name-2" }
+
+      context "given an string dependency tag" do
+        let(:version) { "any_other_string" }
+        it { is_expected.to be_falsey }
+      end
+
+      context "given an bootstrapme dependency tag" do
+        let(:version) { "bootstrapme" }
+        it { is_expected.to be_truthy }
+      end
+
+      context "given an outdated dependency" do
+        let(:version) { "20190620" }
+        it { is_expected.to be_truthy }
+      end
+
+      context "given an outdated dependency" do
+        let(:version) { "20200120" }
+        it { is_expected.to be_truthy }
+      end
+
+      context "given an outdated dependency" do
+        let(:version) { "20190707162045" }
+        it { is_expected.to be_truthy }
+      end
+
+      context "given an outdated dependency" do
+        let(:version) { "20200107242045" }
+        it { is_expected.to be_truthy }
+      end
+
+      context "given an up-to-date dependency" do
+        let(:version) { "20200310162045" }
+        it { is_expected.to be_falsey }
+      end
     end
 
-    context "every time public docker registry times out" do
+    describe "Method #up_to_date?"  do
       before do
         stub_request(:get, "https://registry.hub.docker.com/v2/library/#{dependency_name}/tags/list")
-          .to_raise(RestClient::Exceptions::OpenTimeout)
-      end
-
-      it "raises" do
-        expect { checker.latest_version }
-          .to raise_error(RestClient::Exceptions::OpenTimeout)
-      end
-    end
-
-    context "every time private docker registry times out" do
-      before do
-        stub_request(:get, "https://registry-host.io:5000/v2/#{dependency_name}/tags/list")
-          .to_raise(RestClient::Exceptions::OpenTimeout)
-      end
-
-      let(:source) { { registry: "registry-host.io:5000" } }
-
-      it "raises" do
-        expect { checker.latest_version }
-          .to raise_error(Dependabot::PrivateSourceTimedOut)
-      end
-    end
-
-    context "without authentication credentials" do
-      before do
-        stub_request(:get, "https://registry-host.io:5000/v2/#{dependency_name}/tags/list")
-          .and_return(
-            status: 401,
-            body: "",
-            headers: { 'www_authenticate' => 'basic 123' }
-          )
-      end
-      let(:source) { { registry: "registry-host.io:5000" } }
-
-      it "raises a to PrivateSourceAuthenticationFailure error" do
-        expect { checker.latest_version }
-          .to raise_error(Dependabot::PrivateSourceAuthenticationFailure) do |error|
-            expect(error.source).to eq("registry-host.io:5000")
-          end
-      end
-    end
-
-    context "connects to private registry with authentication credentials and returns" do
-      let(:credentials) do
-        [{
-          'type' => 'docker_registry',
-          'registry' => 'registry-host.io:5000',
-          'username' => 'user',
-          'password' => 'pa55word'
-        }]
-      end
-      let(:source) { { registry: "registry-host.io:5000" } }
-
-      before do
-        tags_url = "https://registry-host.io:5000/v2/#{dependency_name}/tags/list"
-        stub_request(:get, tags_url)
           .and_return(
             status: 200,
-            body: { "name": "library/#{dependency_name}", "tags": ["20191027.8"] }.to_json
+            body: { "name": "library/#{dependency_name}", "tags": ["20200315081015"] }.to_json
           )
       end
+      subject { checker.up_to_date? }
+      let(:dependency_name) { "docker-img-name-1" }
 
-      it { is_expected.to eq("20191027.8") }
-    end
-
-    context "connects to public registry and returns" do
-      let(:credentials) do
-        [{
-          'type' => 'docker_registry',
-          'registry' => 'registry-host.io:5000'
-        }]
+      context "given an string dependency tag" do
+        let(:version) { "any_other_string" }
+        it { is_expected.to be_truthy }
       end
 
-      before do
-        tags_url = "https://registry.hub.docker.com/v2/library/#{dependency_name}/tags/list"
-        stub_request(:get, tags_url)
-          .and_return(
-            status: 200,
-            body: { "name": "library/#{dependency_name}", "tags": ["20191028.2"] }.to_json
-          )
+      context "given an bootstrapme dependency tag" do
+        let(:version) { "bootstrapme" }
+        it { is_expected.to be_falsey }
       end
 
-      it { is_expected.to eq("20191028.2") }
-    end
-  end
-
-  let(:dependency) do
-    Dependabot::Dependency.new(
-      name: dependency_name,
-      version: version,
-      requirements: [{
-        requirement: nil,
-        groups: [],
-        file: "pipeline-template.yml",
-        source: source
-      }],
-      package_manager: "docker"
-    )
-  end
-
-  describe "Method #updated_requirements", :pix4d  do
-    subject { checker.updated_requirements }
-
-    let(:source) { { tag: version } }
-    let(:dependency_name) { "docker-img-name-1" }
-
-    before do
-      tags_url = "https://registry.hub.docker.com/v2/library/#{dependency_name}/tags/list"
-      stub_request(:get, tags_url)
-        .and_return(
-          status: 200,
-          body: { "name": "library/#{dependency_name}", "tags": ["20191028.2"] }.to_json
-        )
-    end
-
-    context "when specified with a tag" do
-      let(:version) { "bootstrapme" }
-      it "updates the tag" do
-        expect(checker.updated_requirements)
-          .to eq(
-            [{
-              requirement: nil,
-              groups: [],
-              file: "pipeline-template.yml",
-              source: { tag: "20191028.2" }
-            }]
-          )
+      context "given an outdated dependency" do
+        let(:version) { "20190620" }
+        it { is_expected.to be_falsey }
       end
+
+      context "given an outdated dependency" do
+        let(:version) { "20200120" }
+        it { is_expected.to be_falsey }
+      end
+
+      context "given an outdated dependency" do
+        let(:version) { "20190707162045" }
+        it { is_expected.to be_falsey }
+      end
+
+      context "given an outdated dependency" do
+        let(:version) { "20200107242045" }
+        it { is_expected.to be_falsey }
+      end
+
+      context "given an up-to-date dependency" do
+        let(:version) { "20200315081015" }
+        it { is_expected.to be_truthy }
+      end
+    end
+
+    describe "Method #latest_version"  do
+      subject { checker.latest_version }
 
       let(:version) { "0" }
-      it "updates the tag" do
-        expect(checker.updated_requirements)
-          .to eq(
-            [{
-              requirement: nil,
-              groups: [],
-              file: "pipeline-template.yml",
-              source: { tag: "20191028.2" }
-            }]
-          )
-      end
+      let(:dependency_name) { "docker-img-name-2" }
 
-      let(:version) { "20150101" }
-      it "updates the tag" do
-        expect(checker.updated_requirements)
-          .to eq(
-            [{
-              requirement: nil,
-              groups: [],
-              file: "pipeline-template.yml",
-              source: { tag: '20191028.2' }
-            }]
-          )
-      end
-    end
-  end
-
-  describe 'when we use python style tags', :pix4d  do
-    let(:dependency_name) { 'python' }
-
-    before do
-      tags_url = "https://registry.hub.docker.com/v2/library/#{dependency_name}/tags/list"
-      stub_request(:get, tags_url)
-        .and_return(
-          status: 200,
-          body: {
-            "name": "library/#{dependency_name}",
-            "tags": ['3.6.0', '3.7.0a2', '3.7.0a2-alpine']
-          }.to_json
-        )
-    end
-
-    context 'Method #up_to_date?' do
-      subject { checker.up_to_date? }
-      context 'given an bootstrapme dependency' do
-        let(:version) { 'bootstrapme' }
-        it { is_expected.to be_falsey }
-      end
-      context 'given an string dependency' do
-        let(:version) { 'anystring' }
-        it { is_expected.to be_truthy }
-      end
-      context 'given an outdated dependency' do
-        let(:version) { '2.5' }
-        it { is_expected.to be_falsey }
-      end
-      context 'given an outdated dependency' do
-        let(:version) { '0' }
-        it { is_expected.to be_falsey }
-      end
-      context 'given an up-to-date dependency' do
-        let(:version) { '3.6.0' }
-        it { is_expected.to be_truthy }
-      end
-      context 'given an outdated pre-release dependency' do
-        let(:version) { '3.7.0a1' }
-        it { is_expected.to be_falsey }
-      end
-      context 'given an up-to-date pre-release dependency' do
-        let(:version) { '3.7.0a2' }
-        it { is_expected.to be_truthy }
-      end
-    end
-
-    context 'Method #can_update?' do
-      subject { checker.can_update?(requirements_to_unlock: :own) }
-
-      context 'given an string dependency tag' do
-        let(:version) { 'any_other_string' }
-        it { is_expected.to be_falsey }
-      end
-
-      context 'given an bootstrapme dependency tag' do
-        let(:version) { 'bootstrapme' }
-        it { is_expected.to be_truthy }
-      end
-
-      context 'given an outdated dependency' do
-        let(:version) { '2.7' }
-        it { is_expected.to be_truthy }
-      end
-
-      context 'given an up-to-date dependency' do
-        let(:version) { '3.6.0' }
-        it { is_expected.to be_falsey }
-      end
-
-      context 'given an outdated pre-release dependency' do
-        let(:version) { '3.7.0a1' }
-        it { is_expected.to be_truthy }
-      end
-
-      context 'given an up-to-date pre-release dependency' do
-        let(:version) { '3.7.0a2' }
-        it { is_expected.to be_falsey }
-      end
-    end
-
-    context 'Method #latest_version' do
-      subject { checker.latest_version }
-
-      context 'given a 2.7 dependency tag' do
-        let(:version) { '2.7' }
-        it { is_expected.to eq('3.6.0') }
-      end
-
-      context 'given a 3.7.0a1 dependency tag' do
-        let(:version) { '3.7.0a1' }
-        it { is_expected.to eq('3.7.0a2') }
-      end
-
-      context 'given a 3.7.1a1-alpine dependency tag' do
-        let(:version) { '3.7.0a1-alpine' }
-        it { is_expected.to eq('3.7.0a2-alpine') }
-      end
-    end
-    context 'Method #updated_requirements' do
-      subject { checker.updated_requirements }
-
-      context 'when specified with a tag' do
-        let(:version) { 'bootstrapme' }
-        it 'updates the tag' do
-          expect(checker.updated_requirements)
-            .to eq(
-              [{
-                requirement: nil,
-                groups: [],
-                file: 'pipeline-template.yml',
-                source: { tag: '3.6.0' }
-              }]
-            )
-        end
-      end
-
-      context 'when specified with a tag' do
-        let(:version) { '3.7.0a1' }
-        it 'updates the tag' do
-          expect(checker.updated_requirements)
-            .to eq(
-              [{
-                requirement: nil,
-                groups: [],
-                file: 'pipeline-template.yml',
-                source: { tag: '3.7.0a2' }
-              }]
-            )
-        end
-      end
-      context 'when specified with a tag' do
-        let(:version) { '0' }
-        it 'updates the tag' do
-          expect(checker.updated_requirements)
-            .to eq(
-              [{
-                requirement: nil,
-                groups: [],
-                file: 'pipeline-template.yml',
-                source: { tag: '3.6.0' }
-              }]
-            )
-        end
-      end
-      context 'when specified with a tag' do
-        let(:version) { '2.6' }
-        it 'updates the tag' do
-          expect(checker.updated_requirements)
-            .to eq(
-              [{
-                requirement: nil,
-                groups: [],
-                file: 'pipeline-template.yml',
-                source: { tag: '3.6.0' }
-              }]
-            )
-        end
-      end
-    end
-
-    describe 'when we use ubuntu style tags' do
-      let(:dependency_name) { 'ubuntu' }
-
-      before do
-        tags_url = "https://registry.hub.docker.com/v2/library/#{dependency_name}/tags/list"
-        stub_request(:get, tags_url)
-          .and_return(
-            status: 200,
-            body: {
-              "name": "library/#{dependency_name}",
-              "tags": ['17.10', 'bionic-20170916', 'xenial-20170916', 'utopic-20191027.11']
-            }.to_json
-          )
-      end
-
-      context 'Method #up_to_date?' do
-        subject { checker.up_to_date? }
-
-        context 'given an bootstrapme dependency' do
-          let(:version) { 'bootstrapme' }
-          it { is_expected.to be_falsey }
-        end
-        context 'given an string dependency' do
-          let(:version) { 'anystring' }
-          it { is_expected.to be_truthy }
-        end
-        context 'given an outdated dependency' do
-          let(:version) { '16.04' }
-          it { is_expected.to be_falsey }
-        end
-        context 'given an outdated dependency' do
-          let(:version) { '0' }
-          it { is_expected.to be_falsey }
-        end
-        context 'given an up-to-date dependency' do
-          let(:version) { '17.10' }
-          it { is_expected.to be_truthy }
-        end
-        context 'given an outdated string-version type dependency' do
-          let(:version) { 'bionic-20160101' }
-          it { is_expected.to be_falsey }
-        end
-        context 'given an up-to-date string-version type dependency' do
-          let(:version) { 'bionic-20170916' }
-          it { is_expected.to be_truthy }
-        end
-        context 'given an outdated string-version type dependency' do
-          let(:version) { 'xenial-20160101' }
-          it { is_expected.to be_falsey }
-        end
-        context 'given an up-to-date string-version type dependency' do
-          let(:version) { 'xenial-20170916' }
-          it { is_expected.to be_truthy }
-        end
-      end
-
-      context 'Method #can_update?' do
-        subject { checker.can_update?(requirements_to_unlock: :own) }
-
-        context 'given an string dependency tag' do
-          let(:version) { 'any_other_string' }
-          it { is_expected.to be_falsey }
-        end
-
-        context 'given an bootstrapme dependency tag' do
-          let(:version) { 'bootstrapme' }
-          it { is_expected.to be_truthy }
-        end
-
-        context 'given an outdated dependency' do
-          let(:version) { '14.04' }
-          it { is_expected.to be_truthy }
-        end
-
-        context 'given an up-to-date dependency' do
-          let(:version) { '17.10' }
-          it { is_expected.to be_falsey }
-        end
-
-        context 'given an outdated string-version typee dependency' do
-          let(:version) { 'bionic-20160202' }
-          it { is_expected.to be_truthy }
-        end
-
-        context 'given an up-to-date string-version type dependency' do
-          let(:version) { 'bionic-20170916' }
-          it { is_expected.to be_falsey }
-        end
-      end
-      context 'Method #latest_version' do
-        subject { checker.latest_version }
-
-        context 'given a 14.04 dependency tag' do
-          let(:version) { '14.04' }
-          it { is_expected.to eq('17.10') }
-        end
-
-        context 'given a bionic-YYYYMMDD dependency tag' do
-          let(:version) { 'bionic-20150101' }
-          it { is_expected.to eq('bionic-20170916') }
-        end
-
-        context 'given a xenial-YYYYMMDD dependency tag' do
-          let(:version) { 'xenial-20150101' }
-          it { is_expected.to eq('xenial-20170916') }
-        end
-        context 'given a utopic-YYYYMMDD.N dependency tag' do
-          let(:version) { 'utopic-20150101' }
-          it { is_expected.to eq('utopic-20191027.11') }
-        end
-
-        context 'given a utopic-YYYYMMDD.N dependency tag' do
-          let(:version) { 'utopic-20150101' }
-          it { is_expected.to eq('utopic-20191027.11') }
-        end
-      end
-      context 'Method #updated_requirements' do
-        subject { checker.updated_requirements }
-
-        context 'when specified with a tag' do
-          let(:version) { 'bootstrapme' }
-          it 'updates the tag' do
-            expect(checker.updated_requirements)
-              .to eq(
-                [{
-                  requirement: nil,
-                  groups: [],
-                  file: 'pipeline-template.yml',
-                  source: { tag: '17.10' }
-                }]
-              )
-          end
-        end
-        context 'when specified with a tag' do
-          let(:version) { 'xenial-20140101' }
-          it 'updates the tag' do
-            expect(checker.updated_requirements)
-              .to eq(
-                [{
-                  requirement: nil,
-                  groups: [],
-                  file: 'pipeline-template.yml',
-                  source: { tag: 'xenial-20170916' }
-                }]
-              )
-          end
-        end
-        context 'when specified with a tag' do
-          let(:version) { '14.04' }
-          it 'updates the tag' do
-            expect(checker.updated_requirements)
-              .to eq(
-                [{
-                  requirement: nil,
-                  groups: [],
-                  file: 'pipeline-template.yml',
-                  source: { tag: '17.10' }
-                }]
-              )
-          end
-        end
-      end
-    end
-
-    describe 'Method #up_to_date (new tag format)?' do
-      before do
-        stub_request(:get, "https://registry.hub.docker.com/v2/library/#{dependency_name}/tags/list")
-          .and_return(
-            status: 200,
-            body: { "name": "library/#{dependency_name}", "tags": ['20171025090000'] }.to_json
-          )
-      end
-      subject { checker.up_to_date? }
-      let(:dependency_name) { 'docker-img-name-1' }
-
-      context 'given an string dependency tag' do
-        let(:version) { 'any_other_string' }
-        it { is_expected.to be_truthy }
-      end
-
-      context 'given an bootstrapme dependency tag' do
-        let(:version) { 'bootstrapme' }
-        it { is_expected.to be_falsey }
-      end
-
-      context 'given an outdated dependency in format YYYYMMDD' do
-        let(:version) { '20150620' }
-        it { is_expected.to be_falsey }
-      end
-
-      context 'given an outdated dependency in format YYYYMMDD.N' do
-        let(:version) { '20150620.1' }
-        it { is_expected.to be_falsey }
-      end
-
-      context 'given an outdated dependency' do
-        let(:version) { '20150620150000' }
-        it { is_expected.to be_falsey }
-      end
-
-      context 'given an up-to-date dependency' do
-        let(:version) { '20171025090000'}
-        it { is_expected.to be_truthy }
-      end
-    end
-
-    describe 'Method #can_update (new tag format)?' do
-      before do
-        stub_request(:get, "https://registry.hub.docker.com/v2/library/#{dependency_name}/tags/list")
-          .and_return(
-            status: 200,
-            body: { "name": "library/#{dependency_name}", "tags": ['20191025090000'] }.to_json
-          )
-      end
-
-      subject { checker.can_update?(requirements_to_unlock: :own) }
-
-      let(:dependency_name) { 'docker-img-name-2' }
-
-      context 'given an string dependency tag' do
-        let(:version) { 'any_other_string' }
-        it { is_expected.to be_falsey }
-      end
-
-      context 'given an bootstrapme dependency tag' do
-        let(:version) { 'bootstrapme' }
-        it { is_expected.to be_truthy }
-      end
-
-      context 'given an outdated dependency' do
-        let(:version) { '20190620140000' }
-        it { is_expected.to be_truthy }
-      end
-
-      context 'given an up-to-date dependency' do
-        let(:version) { '20191025140000' }
-        it { is_expected.to be_falsey }
-      end
-    end
-
-    describe 'Method #latest_version (new tag format)' do
-      subject { checker.latest_version }
-
-      let(:version) { '0' }
-      let(:dependency_name) { 'docker-img-name-2' }
-
-      context 'return latest tag' do
+      context "return latest tag" do
         before do
           stub_request(:get, "https://registry.hub.docker.com/v2/library/#{dependency_name}/tags/list")
             .and_return(
               status: 200,
-              body: { "name": "library/#{dependency_name}", "tags": ['20191025090000'] }.to_json
+              body: { "name": "library/#{dependency_name}", "tags": ["20200320091510"] }.to_json
             )
         end
 
-        it { is_expected.to eq('20191025090000') }
+        it { is_expected.to eq("20200320091510") }
       end
 
-      context 'connects to private registry with authentication credentials and returns' do
+      context "every time public docker registry times out" do
+        before do
+          stub_request(:get, "https://registry.hub.docker.com/v2/library/#{dependency_name}/tags/list")
+            .to_raise(RestClient::Exceptions::OpenTimeout)
+        end
+
+        it "raises" do
+          expect { checker.latest_version }
+            .to raise_error(RestClient::Exceptions::OpenTimeout)
+        end
+      end
+
+      context "every time private docker registry times out" do
+        before do
+          stub_request(:get, "https://registry-host.io:5000/v2/#{dependency_name}/tags/list")
+            .to_raise(RestClient::Exceptions::OpenTimeout)
+        end
+
+        let(:source) { { registry: "registry-host.io:5000" } }
+
+        it "raises" do
+          expect { checker.latest_version }
+            .to raise_error(Dependabot::PrivateSourceTimedOut)
+        end
+      end
+
+      context "without authentication credentials" do
+        before do
+          stub_request(:get, "https://registry-host.io:5000/v2/#{dependency_name}/tags/list")
+            .and_return(
+              status: 401,
+              body: "",
+              headers: { 'www_authenticate' => 'basic 123' }
+            )
+        end
+        let(:source) { { registry: "registry-host.io:5000" } }
+
+        it "raises a to PrivateSourceAuthenticationFailure error" do
+          expect { checker.latest_version }
+            .to raise_error(Dependabot::PrivateSourceAuthenticationFailure) do |error|
+              expect(error.source).to eq("registry-host.io:5000")
+            end
+        end
+      end
+
+      context "connects to private registry with authentication credentials and returns" do
         let(:credentials) do
           [{
             'type' => 'docker_registry',
@@ -1324,21 +801,21 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
             'password' => 'pa55word'
           }]
         end
-        let(:source) { { registry: 'registry-host.io:5000' } }
+        let(:source) { { registry: "registry-host.io:5000" } }
 
         before do
           tags_url = "https://registry-host.io:5000/v2/#{dependency_name}/tags/list"
           stub_request(:get, tags_url)
             .and_return(
               status: 200,
-              body: { "name": "library/#{dependency_name}", "tags": ['20191027090000'] }.to_json
+              body: { "name": "library/#{dependency_name}", "tags": ["bootstrapme","20190220091510","20200220091510","20200320091510"] }.to_json
             )
         end
 
-        it { is_expected.to eq('20191027090000') }
+        it { is_expected.to eq("20200320091510") }
       end
 
-      context 'connects to public registry and returns' do
+      context "connects to public registry and returns" do
         let(:credentials) do
           [{
             'type' => 'docker_registry',
@@ -1351,69 +828,115 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
           stub_request(:get, tags_url)
             .and_return(
               status: 200,
-              body: { "name": "library/#{dependency_name}", "tags": ['20191028090000'] }.to_json
+              body: { "name": "library/#{dependency_name}", "tags": ["20190220","20200302","20200320091510"] }.to_json
             )
         end
 
-        it { is_expected.to eq('20191028090000') }
+        it { is_expected.to eq("20200320091510") }
       end
+
+      context "return latest tag if actual latest tag exist" do
+        let(:version) { "20200301" }
+        let(:dependency_name) { "docker-img-name-5" }
+
+        before do
+          stub_request(:get, "https://registry.hub.docker.com/v2/library/#{dependency_name}/tags/list").
+            and_return(
+              status: 200,
+              body: { "name": "library/#{dependency_name}", "tags": ["20200301","20200302","latest","20200320091510"] }.to_json
+            )
+          stub_request(:head, "https://registry.hub.docker.com/v2/library/#{dependency_name}/manifests/latest").
+            and_return(
+              status: 200,
+              headers: JSON.parse('{"docker_content_digest":"sha256:123"}'))
+          stub_request(:head, "https://registry.hub.docker.com/v2/library/#{dependency_name}/manifests/20200320091510").
+            and_return(
+              status: 200,
+              headers: JSON.parse('{"docker_content_digest":"sha256:123"}'))
+        end
+
+        it { is_expected.to eq("20200320091510") }
+      end
+
     end
 
-    describe 'Method #updated_requirements (new tag format)' do
+    describe "Method #updated_requirements"  do
       subject { checker.updated_requirements }
 
-      let(:source) { { tag: version } }
-      let(:dependency_name) { 'docker-img-name-1' }
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: dependency_name,
+          version: version,
+          requirements: [{
+            requirement: nil,
+            groups: [],
+            file: "pipeline-template.yml",
+            source: source
+          }],
+          package_manager: "docker"
+        )
+      end
+
+      let(:dependency_name) { "docker-img-name-1" }
 
       before do
         tags_url = "https://registry.hub.docker.com/v2/library/#{dependency_name}/tags/list"
         stub_request(:get, tags_url)
           .and_return(
             status: 200,
-            body: { "name": "library/#{dependency_name}", "tags": ['20191028090000'] }.to_json
+            body: { "name": "library/#{dependency_name}", "tags": ["bootstrapme","20190220091510","20200220091510","20200320091510"] }.to_json
           )
       end
 
-      context 'when specified with a tag' do
-        let(:version) { 'bootstrapme' }
-        it 'updates the tag' do
-          expect(checker.updated_requirements)
-            .to eq(
-              [{
-                requirement: nil,
-                groups: [],
-                file: 'pipeline-template.yml',
-                source: { tag: '20191028090000' }
-              }]
-            )
-        end
+      context "when specified with a tag" do
+        let(:version) { "bootstrapme" }
 
-        let(:version) { '0' }
-        it 'updates the tag' do
+        it "updates the bootstrapme tag" do
           expect(checker.updated_requirements)
             .to eq(
               [{
                 requirement: nil,
                 groups: [],
-                file: 'pipeline-template.yml',
-                source: { tag: '20191028090000' }
-              }]
-            )
-        end
-
-        let(:version) { '20150101' }
-        it 'updates the tag' do
-          expect(checker.updated_requirements)
-            .to eq(
-              [{
-                requirement: nil,
-                groups: [],
-                file: 'pipeline-template.yml',
-                source: { tag: '20191028090000' }
+                file: "pipeline-template.yml",
+                source: { tag: "20200320091510" }
               }]
             )
         end
       end
+
+      context "when specified with a tag" do
+        let(:version) { "0" }
+
+        it "updates the tag" do
+          expect(checker.updated_requirements)
+            .to eq(
+              [{
+                requirement: nil,
+                groups: [],
+                file: "pipeline-template.yml",
+                source: { tag: "20200320091510" }
+              }]
+            )
+        end
+      end
+
+      context "when specified with a tag" do
+        let(:version) { "20190101" }
+
+        it "updates the tag" do
+          expect(checker.updated_requirements)
+            .to eq(
+              [{
+                requirement: nil,
+                groups: [],
+                file: "pipeline-template.yml",
+                source: { tag: "20200320091510" }
+              }]
+            )
+        end
+      end
+
     end
+
   end
 end

--- a/docker/spec/fixtures/pipelines/pix4d-special.yml
+++ b/docker/spec/fixtures/pipelines/pix4d-special.yml
@@ -1,0 +1,26 @@
+---
+resources:
+
+- name: private-image-name-bootstrap.docker
+  type: registry-image
+  source:
+    username: here_is_the_username
+    password: here_is_the_password
+    repository: private.repo.com/private-image-name
+    tag: "bootstrapme"
+
+  - name: private-image-name-bootstrap.docker
+    type: registry-image
+    source:
+      username: here_is_the_username
+      password: here_is_the_password
+      repository: private.repo.com/private-image-name-16.04
+      tag: bootstrapme
+
+  - name: private-image-name-quotes.docker
+    type: registry-image
+    source:
+      username: here_is_the_username
+      password: here_is_the_password
+      repository: private.repo.com/private-image-name-18.04
+      tag: "20200220151020"

--- a/docker/update_script.rb
+++ b/docker/update_script.rb
@@ -44,9 +44,9 @@ fetcher = Dependabot::FileFetchers.for_package_manager(package_manager).
 files = fetcher.files
 commit = fetcher.commit
 
-# ##############################
-# # Parse the dependency files #
-# ##############################
+##############################
+# Parse the dependency files #
+##############################
 parser = Dependabot::FileParsers.for_package_manager(package_manager).new(
   dependency_files: files,
   source: source
@@ -62,8 +62,6 @@ dependencies.select(&:top_level?).each do |dep|
     dependency_files: files,
     credentials: credentials_docker,
   )
-  puts dep.name
-  #puts checker.up_to_date?
   next if checker.up_to_date?
 
   requirements_to_unlock =


### PR DESCRIPTION
- Dependabot is modified to fetch both Dockerfiles and pipeline templates
- both upstream and terraform imported tests are now passing
- minimize the difference between upstream and forked master
- fixed/correctly implemented broken tests imported from terraform
- existing double quotes around tags are removed

`bundle exec rspec spec` output:
```
Finished in 1.79 seconds (files took 0.66434 seconds to load)
247 examples, 0 failures

Randomized with seed 15106
```
The same source code created all opened PRs: 
https://github.com/Pix4D/test-dependabot-docker/pulls
As expected the PR was not opened only for the following Dockerfile
`ci/docker/docker-folder-2/Dockerfile` 
`FROM ubuntu:bionic-20190912.1`
due to a bug already reported upstream by the CI team.

The difference between two runs (PRs for Dockerfiles and PRs for templeate file) is in the main script `update_script.rb`
- in a second PR the goal is to rename `update_script.rb` to a less confusing name i.e. `dependabot.rb`
- use a single script to update either Dockerfiles or template files base on the passed environmental variable.

Main advantages of continuing with this approach:
1) single, maintainable source code can be used to update both Dockerfiles and template files
2) reduces number of Dockerfiles and Docker images needed (now its three)  to one
3) reduces the confusion with names (`Dependabot Docker and Docker updater`) and script names (`update_script.rb`)and removes the code from `terraform-tomato`