### PR TITLE
Pci 1202 rubocop changes

### DIFF
--- a/docker/dependabot-main.rb
+++ b/docker/dependabot-main.rb
@@ -14,6 +14,33 @@ require "dependabot/docker"
 require "dependabot/pr_info"
 require "dependabot/path_level.rb"
 
+def pr_creator(source, commit, updated_deps, updated_files, credentials_github)
+  Dependabot::PullRequestCreator.new(
+    source: source,
+    base_commit: commit,
+    dependencies: updated_deps,
+    files: updated_files,
+    credentials: credentials_github,
+    label_language: true,
+    branch_name_prefix: nil,
+    branch_name_separator: "-",
+    pr_message_footer: pr_info(updated_deps.first)
+  )
+end
+
+def requirements(checker)
+  requirements =
+    if !checker.requirements_unlocked_or_can_be?
+      if checker.can_update?(requirements_to_unlock: :none) then :none
+      else :update_not_possible
+      end
+    elsif checker.can_update?(requirements_to_unlock: :own) then :own
+    elsif checker.can_update?(requirements_to_unlock: :all) then :all
+    else :update_not_possible
+    end
+  requirements
+end
+
 credentials_github =
   [{
     "type" => "git_source",
@@ -38,56 +65,32 @@ input_files_path = recursive_path(
 )
 
 input_files_path.each do |file_path|
-  #
   # Source setup
-  #
   print "  - Checking the file in #{file_path}\n"
   source = Dependabot::Source.new(
-    provider: "github",
-    repo: ENV["PROJECT_PATH"],
-    directory: file_path,
-    branch: (ENV["REPOSITORY_BRANCH"] || nil)
+    provider: "github", repo: ENV["PROJECT_PATH"],
+    directory: file_path, branch: (ENV["REPOSITORY_BRANCH"] || nil)
   )
-
-  #
   # Fetch the dependency files
-  #
   fetcher = Dependabot::FileFetchers.for_package_manager("docker").
             new(source: source, credentials: credentials_github)
 
   files = fetcher.files
   commit = fetcher.commit
-
-  #
   # Parse the dependency files
-  #
   parser = Dependabot::FileParsers.for_package_manager("docker").new(
-    dependency_files: files,
-    source: source
+    dependency_files: files, source: source
   )
   dependencies = parser.parse
 
   dependencies.select(&:top_level?).each do |dep|
-    #
     # Get update details for the dependency
-    #
     checker = Dependabot::UpdateCheckers.for_package_manager("docker").new(
-      dependency: dep,
-      dependency_files: files,
-      credentials: credentials_docker
+      dependency: dep, dependency_files: files, credentials: credentials_docker
     )
     next if checker.up_to_date?
 
-    requirements_to_unlock =
-      if !checker.requirements_unlocked_or_can_be?
-        if checker.can_update?(requirements_to_unlock: :none) then :none
-        else :update_not_possible
-        end
-      elsif checker.can_update?(requirements_to_unlock: :own) then :own
-      elsif checker.can_update?(requirements_to_unlock: :all) then :all
-      else :update_not_possible
-      end
-
+    requirements_to_unlock = requirements(checker)
     next if requirements_to_unlock == :update_not_possible
 
     updated_deps = checker.updated_dependencies(
@@ -96,34 +99,18 @@ input_files_path.each do |file_path|
 
     next if updated_deps.first.version == updated_deps.first.previous_version
 
-    #
     # Generate updated dependency files
-    #
     print "  - Updating #{dep.name} (from #{dep.version}) \n"
     updater = Dependabot::FileUpdaters.for_package_manager("docker").new(
-      dependencies: updated_deps,
-      dependency_files: files,
-      credentials: nil
+      dependencies: updated_deps, dependency_files: files, credentials: nil
     )
     updated_files = updater.updated_dependency_files
 
-    #
     # Create a pull request for the update
-    #
-    pr_creator = Dependabot::PullRequestCreator.new(
-      source: source,
-      base_commit: commit,
-      dependencies: updated_deps,
-      files: updated_files,
-      credentials: credentials_github,
-      label_language: true,
-      branch_name_prefix: nil,
-      branch_name_separator: "-",
-      pr_message_footer: pr_info(updated_deps.first)
-    )
+    pr = pr_creator(source, commit, updated_deps,
+                    updated_files, credentials_github)
 
-    pull_request = pr_creator.create
-    puts " submitted"
+    pull_request = pr.create
 
     next unless pull_request
   end

--- a/docker/dependabot-main.rb
+++ b/docker/dependabot-main.rb
@@ -1,12 +1,14 @@
+# frozen_string_literal: true
+
 # LIST OF ENVIROMENTAL VARIABLES NEEDED:
-  # FEATURE_PACKAGE i.e docker or concourse
-  # PROJECT_PATH i.e. Pix4D/test-dependabot-docker
-  # DEPENDENCY_DIRECTORY i.e. ci/docker or ci/pipelines
-  # REPOSITORY_BRANCH default is master
-  # GITHUB_ACCESS_TOKEN
-  # DOCKER_REGISTRY i.e. docker.ci.pix4d.com
-  # DOCKER_USER
-  # DOCKER_PASS
+# FEATURE_PACKAGE i.e docker or concourse
+# PROJECT_PATH i.e. Pix4D/test-dependabot-docker
+# DEPENDENCY_DIRECTORY i.e. ci/docker or ci/pipelines
+# REPOSITORY_BRANCH default is master
+# GITHUB_ACCESS_TOKEN
+# DOCKER_REGISTRY i.e. docker.ci.pix4d.com
+# DOCKER_USER
+# DOCKER_PASS
 
 require "dependabot/docker"
 require "dependabot/pr_info"
@@ -23,7 +25,7 @@ credentials_github =
 credentials_docker =
   [{
     "type" => "docker_registry",
-    "registry" => (ENV["DOCKER_REGISTRY"]  || "registry.hub.docker.com"),
+    "registry" => (ENV["DOCKER_REGISTRY"] || "registry.hub.docker.com"),
     "username" => (ENV["DOCKER_USER"] || nil),
     "password" => (ENV["DOCKER_PASS"] || nil)
   }]
@@ -36,7 +38,6 @@ input_files_path = recursive_path(
 )
 
 input_files_path.each do |file_path|
-
   #
   # Source setup
   #
@@ -73,7 +74,7 @@ input_files_path.each do |file_path|
     checker = Dependabot::UpdateCheckers.for_package_manager("docker").new(
       dependency: dep,
       dependency_files: files,
-      credentials: credentials_docker,
+      credentials: credentials_docker
     )
     next if checker.up_to_date?
 
@@ -94,6 +95,7 @@ input_files_path.each do |file_path|
     )
 
     next if updated_deps.first.version == updated_deps.first.previous_version
+
     #
     # Generate updated dependency files
     #

--- a/docker/lib/dependabot/docker/file_fetcher.rb
+++ b/docker/lib/dependabot/docker/file_fetcher.rb
@@ -6,8 +6,9 @@ require "dependabot/file_fetchers/base"
 module Dependabot
   module Docker
     class FileFetcher < Dependabot::FileFetchers::Base
+      PATH_REGEX = /dockerfile|template|docker-image-version/i.freeze
       def self.required_files_in?(filenames)
-        filenames.any? { |f| f.match?(/dockerfile|template|docker-image-version/i) }
+        filenames.any? { |f| f.match?(PATH_REGEX) }
       end
 
       def self.required_files_message
@@ -25,7 +26,8 @@ module Dependabot
         if incorrectly_encoded_file.none?
           raise(
             Dependabot::DependencyFileNotFound,
-            "No Dockerfile or Concourse pipeline file found at path: #{directory}."
+            "No Dockerfile or Concourse pipeline file \
+            found at path: #{directory}."
           )
         else
           raise(
@@ -38,7 +40,7 @@ module Dependabot
       def fetched_file
         @fetched_file ||=
           repo_contents(raise_errors: false).
-          select { |f| f.type == "file" && f.name.match?(/dockerfile|template|docker-image-version/i) }.
+          select { |f| f.type == "file" && f.name.match?(PATH_REGEX) }.
           map { |f| fetch_file_from_host(f.name) }
       end
 

--- a/docker/lib/dependabot/docker/file_updater.rb
+++ b/docker/lib/dependabot/docker/file_updater.rb
@@ -52,7 +52,7 @@ module Dependabot
                               update_digest_and_tag(file)
                             else
                               update_tag_docker(file)
-                              end
+                            end
                           else
                             update_tag_template(file)
                           end
@@ -111,12 +111,16 @@ module Dependabot
             end
           old_declaration += dependency.name.to_s
           escaped_declaration = Regexp.escape(old_declaration)
-
           old_declaration_regex =
-            %r{repository:\s+(docker\.io/)?#{escaped_declaration}(?=\s|$)\n + (tag:\s[^\n]+)\n}
+            %r{repository:\s+(docker\.io/)?#{escaped_declaration}(?=\s|$)\n\s+
+            \s(tag:\s[^\n]+)\n}x
+
           modified_content = modified_content.
                              gsub(old_declaration_regex) do |old_dec|
-            old_dec.gsub(/(tag:\s#{old_tag})|(tag:\s"#{old_tag}")/, "tag:\s#{new_tag(file)}")
+            old_dec.gsub(
+              /(tag:\s#{old_tag})|(tag:\s"#{old_tag}")/,
+              "tag:\s#{new_tag(file)}"
+            )
           end
         end
 

--- a/docker/lib/dependabot/docker/file_updater.rb
+++ b/docker/lib/dependabot/docker/file_updater.rb
@@ -47,16 +47,15 @@ module Dependabot
       end
 
       def updated_file_content(file)
-        if file.name.match?(/dockerfile|custom/i)
-          updated_content =
-            if specified_with_digest?(file)
-              update_digest_and_tag(file)
-            else
-              update_tag_docker(file)
-            end
-        else
-          updated_content = update_tag_template(file)
-        end
+        updated_content = if file.name.match?(/dockerfile|custom/i)
+                            if specified_with_digest?(file)
+                              update_digest_and_tag(file)
+                            else
+                              update_tag_docker(file)
+                              end
+                          else
+                            update_tag_template(file)
+                          end
         raise "Expected content to change!" if updated_content == file.content
 
         updated_content
@@ -110,14 +109,14 @@ module Dependabot
             if private_registry_url(file) then "#{private_registry_url(file)}/"
             else ""
             end
-            old_declaration += "#{dependency.name}"
-            escaped_declaration = Regexp.escape(old_declaration)
+          old_declaration += dependency.name.to_s
+          escaped_declaration = Regexp.escape(old_declaration)
 
-            old_declaration_regex =
-              %r{repository:\s+(docker\.io/)?#{escaped_declaration}(?=\s|$)\n + (tag:\s[^\n]+)\n}
-            modified_content = modified_content.
-                              gsub(old_declaration_regex) do |old_dec|
-                                old_dec.gsub(/(tag:\s#{old_tag})|(tag:\s"#{old_tag}")/, "tag:\s#{new_tag(file)}")
+          old_declaration_regex =
+            %r{repository:\s+(docker\.io/)?#{escaped_declaration}(?=\s|$)\n + (tag:\s[^\n]+)\n}
+          modified_content = modified_content.
+                             gsub(old_declaration_regex) do |old_dec|
+            old_dec.gsub(/(tag:\s#{old_tag})|(tag:\s"#{old_tag}")/, "tag:\s#{new_tag(file)}")
           end
         end
 

--- a/docker/lib/dependabot/docker/update_checker.rb
+++ b/docker/lib/dependabot/docker/update_checker.rb
@@ -77,12 +77,10 @@ module Dependabot
       end
 
       def version_tag_up_to_date?
-        if not (dependency.version.match?(NAME_WITH_VERSION) || dependency.version == BOOTSTRAP_TAG)
+        unless dependency.version.match?(NAME_WITH_VERSION) || dependency.version == BOOTSTRAP_TAG
           return
         end
-        if dependency.version == BOOTSTRAP_TAG
-          return false
-        end
+        return false if dependency.version == BOOTSTRAP_TAG
 
         old_v = numeric_version_from(dependency.version)
         latest_v = numeric_version_from(latest_version)
@@ -120,9 +118,9 @@ module Dependabot
         candidate_tags = non_downgrade_tags if non_downgrade_tags.any?
 
         wants_prerelease = if dependency.version == BOOTSTRAP_TAG
-          false
-        else
-          prerelease?(dependency.version)
+                             false
+                           else
+                             prerelease?(dependency.version)
         end
         candidate_tags =
           candidate_tags.
@@ -139,7 +137,6 @@ module Dependabot
           end
 
         latest_tag || dependency.version
-
       end
 
       def comparable_tags_from_registry
@@ -265,25 +262,19 @@ module Dependabot
       end
 
       def prefix_of(tag)
-        if tag == BOOTSTRAP_TAG
-          return nil
-        end
+        return nil if tag == BOOTSTRAP_TAG
 
         tag.match(NAME_WITH_VERSION).named_captures.fetch("prefix")
       end
 
       def suffix_of(tag)
-        if tag == BOOTSTRAP_TAG
-          return nil
-        end
+        return nil if tag == BOOTSTRAP_TAG
 
         tag.match(NAME_WITH_VERSION).named_captures.fetch("suffix")
       end
 
       def format_of(tag)
-        if tag == BOOTSTRAP_TAG
-          return :build_num
-        end
+        return :build_num if tag == BOOTSTRAP_TAG
 
         version = numeric_version_from(tag)
 

--- a/docker/lib/dependabot/docker/update_checker.rb
+++ b/docker/lib/dependabot/docker/update_checker.rb
@@ -77,7 +77,8 @@ module Dependabot
       end
 
       def version_tag_up_to_date?
-        unless dependency.version.match?(NAME_WITH_VERSION) || dependency.version == BOOTSTRAP_TAG
+        unless dependency.version.match?(NAME_WITH_VERSION) ||
+               dependency.version == BOOTSTRAP_TAG
           return
         end
         return false if dependency.version == BOOTSTRAP_TAG
@@ -107,7 +108,8 @@ module Dependabot
       # Note: It's important that this *always* returns a version (even if
       # it's the existing one) as it is what we later check the digest of.
       def fetch_latest_version
-        unless dependency.version.match?(NAME_WITH_VERSION) || dependency.version == BOOTSTRAP_TAG
+        unless dependency.version.match?(NAME_WITH_VERSION) ||
+               dependency.version == BOOTSTRAP_TAG
           return dependency.version
         end
 
@@ -117,11 +119,7 @@ module Dependabot
         non_downgrade_tags = remove_version_downgrades(candidate_tags)
         candidate_tags = non_downgrade_tags if non_downgrade_tags.any?
 
-        wants_prerelease = if dependency.version == BOOTSTRAP_TAG
-                             false
-                           else
-                             prerelease?(dependency.version)
-        end
+        wants_prerelease = prerelease?(dependency.version)
         candidate_tags =
           candidate_tags.
           reject { |tag| prerelease?(tag) && !wants_prerelease }.
@@ -286,6 +284,7 @@ module Dependabot
       end
 
       def prerelease?(tag)
+        return false if tag == BOOTSTRAP_TAG
         if numeric_version_from(tag).gsub(/kb/i, "").match?(/[a-zA-Z]/)
           return true
         end

--- a/docker/lib/dependabot/path_level.rb
+++ b/docker/lib/dependabot/path_level.rb
@@ -1,22 +1,22 @@
-def recursive_path(feature_package, project_path, dependency_dir, github_token)
+# frozen_string_literal: true
 
+def recursive_path(feature_package, project_path, dependency_dir, github_token)
   if feature_package == "docker"
 
-    client = Octokit::Client.new(:access_token => github_token)
-    branch= client.branch(project_path, "master")
-    tree = client.tree(project_path, branch.commit.sha, :recursive => true).tree
+    client = Octokit::Client.new(access_token: github_token)
+    branch = client.branch(project_path, "master")
+    tree = client.tree(project_path, branch.commit.sha, recursive: true).tree
 
-    selected_paths = tree.select {|f| f.path.include?("#{dependency_dir}")}.
-                      select {|f| f.path.include?("Dockerfile")}.
-                      map {|f| f.path}
+    selected_paths = tree.select { |f| f.path.include?(dependency_dir.to_s) }.
+                     select { |f| f.path.include?("Dockerfile") }.
+                     map(&:path)
 
     input_files_path = []
     selected_paths.each do |path|
-        path.slice! "/Dockerfile"
-        input_files_path << path
+      path.slice! "/Dockerfile"
+      input_files_path << path
     end
   else
     input_files_path = [dependency_dir]
   end
-
 end

--- a/docker/lib/dependabot/pr_info.rb
+++ b/docker/lib/dependabot/pr_info.rb
@@ -1,23 +1,24 @@
-# frozen_string_literal: true
-
+# rubocop:disable Style/FrozenStringLiteralComment
 require "cgi"
 require "uri"
 
 def pr_info(dependency)
   info = "More information can be found at: "
-  if using_dockerhub? dependency
-    info << URI.join(
-      "https://hub.docker.com/_/",
-      CGI.escape(dependency.name) + "?" +
-      URI.encode_www_form([
-                            %w(tab tags),
-                            ["name", dependency.version]
-                          ])
-    ).to_s
-  else
-    info << URI.join("https://github.com/Pix4D/linux-image-build/releases/tag/",
-                     CGI.escape("#{dependency.name}-#{dependency.version}")).to_s
-  end
+  info << if using_dockerhub? dependency
+            URI.join(
+              "https://hub.docker.com/_/",
+              CGI.escape(dependency.name) + "?" +
+              URI.encode_www_form([
+                                    %w(tab tags),
+                                    ["name", dependency.version]
+                                  ])
+            ).to_s
+          else
+            URI.join("https://github.com/Pix4D/linux-image-build/releases/tag/",
+                     CGI.escape(
+                       "#{dependency.name}-#{dependency.version}"
+                     )).to_s
+          end
 end
 
 def using_dockerhub?(dependency)
@@ -27,3 +28,4 @@ def using_dockerhub?(dependency)
 
   dependency.requirements.first[:source][:registry].nil?
 end
+# rubocop:enable Style/FrozenStringLiteralComment

--- a/docker/lib/dependabot/pr_info.rb
+++ b/docker/lib/dependabot/pr_info.rb
@@ -1,16 +1,18 @@
+# frozen_string_literal: true
+
 require "cgi"
 require "uri"
 
 def pr_info(dependency)
   info = "More information can be found at: "
-  if using_dockerhub? dependency then
+  if using_dockerhub? dependency
     info << URI.join(
       "https://hub.docker.com/_/",
       CGI.escape(dependency.name) + "?" +
       URI.encode_www_form([
-        ["tab", "tags"],
-        ["name", dependency.version]
-      ])
+                            %w(tab tags),
+                            ["name", dependency.version]
+                          ])
     ).to_s
   else
     info << URI.join("https://github.com/Pix4D/linux-image-build/releases/tag/",
@@ -18,7 +20,10 @@ def pr_info(dependency)
   end
 end
 
-def using_dockerhub? dependency
-  raise ArgumentError, "Dependency must have exactly one requirement" unless dependency.requirements.length == 1
+def using_dockerhub?(dependency)
+  unless dependency.requirements.length == 1
+    raise ArgumentError, "Dependency must have exactly one requirement"
+  end
+
   dependency.requirements.first[:source][:registry].nil?
 end

--- a/docker/spec/dependabot/docker/file_fetcher_spec.rb
+++ b/docker/spec/dependabot/docker/file_fetcher_spec.rb
@@ -312,7 +312,7 @@ RSpec.describe Dependabot::Docker::FileFetcher do
         to_return(
           status: 200,
           body: '{
-            "content": "RlJPTSB1YnVudHU6MTguMDQKCiMjIyBTWVNURU0gREVQRU5ERU5DSUVTCgoj\n",
+            "content": "RlJPTSB1Y\n",
             "encoding": "base64"
             }',
           headers: json_content_type

--- a/docker/spec/dependabot/docker/file_fetcher_spec.rb
+++ b/docker/spec/dependabot/docker/file_fetcher_spec.rb
@@ -190,15 +190,15 @@ RSpec.describe Dependabot::Docker::FileFetcher do
     it "fetches the pipeline template" do
       expect(file_fetcher_instance.files.count).to eq(1)
       expect(file_fetcher_instance.files.map(&:name)).
-        to match_array(%w[pipeline-template.yml])
+        to match_array(%w(pipeline-template.yml))
     end
 
     context "that has an invalid encoding" do
       let(:file_fixture) { fixture("github", "contents_image.json") }
 
       it "raises a helpful error" do
-        expect { file_fetcher_instance.files }
-          .to raise_error(Dependabot::DependencyFileNotParseable)
+        expect { file_fetcher_instance.files }.
+          to raise_error(Dependabot::DependencyFileNotParseable)
       end
     end
   end
@@ -206,23 +206,23 @@ RSpec.describe Dependabot::Docker::FileFetcher do
   context "with multiple template files", :pix4d do
     it_behaves_like "a dependency file fetcher"
     before do
-      stub_request(:get, url + "?ref=sha")
-        .with(headers: token)
-        .to_return(
+      stub_request(:get, url + "?ref=sha").
+        with(headers: token).
+        to_return(
           status: 200,
           body: fixture("github", "contents_pipeline_repo_multiple.json"),
           headers: json_content_type
         )
-      stub_request(:get, File.join(url, "pipeline-template.yml?ref=sha"))
-        .with(headers: token)
-        .to_return(
+      stub_request(:get, File.join(url, "pipeline-template.yml?ref=sha")).
+        with(headers: token).
+        to_return(
           status: 200,
           body: file_fixture,
           headers: json_content_type
         )
-      stub_request(:get, File.join(url, "pipeline-template-base.yml?ref=sha"))
-        .with(headers: token)
-        .to_return(
+      stub_request(:get, File.join(url, "pipeline-template-base.yml?ref=sha")).
+        with(headers: token).
+        to_return(
           status: 200,
           body: file_2_fixture,
           headers: json_content_type
@@ -234,8 +234,8 @@ RSpec.describe Dependabot::Docker::FileFetcher do
 
     it "fetches both template files" do
       expect(file_fetcher_instance.files.count).to eq(2)
-      expect(file_fetcher_instance.files.map(&:name))
-        .to match_array(%w[pipeline-template.yml pipeline-template-base.yml])
+      expect(file_fetcher_instance.files.map(&:name)).
+        to match_array(%w(pipeline-template.yml pipeline-template-base.yml))
     end
 
     context "one of which has an invalid encoding" do
@@ -243,8 +243,8 @@ RSpec.describe Dependabot::Docker::FileFetcher do
 
       it "fetches the first file, and ignores the invalid one" do
         expect(file_fetcher_instance.files.count).to eq(1)
-        expect(file_fetcher_instance.files.map(&:name))
-          .to match_array(%w[pipeline-template.yml])
+        expect(file_fetcher_instance.files.map(&:name)).
+          to match_array(%w(pipeline-template.yml))
       end
     end
   end
@@ -252,17 +252,17 @@ RSpec.describe Dependabot::Docker::FileFetcher do
   context "with a custom named template file", :pix4d do
     it_behaves_like "a dependency file fetcher"
     before do
-      stub_request(:get, url + "?ref=sha")
-        .with(headers: token)
-        .to_return(
+      stub_request(:get, url + "?ref=sha").
+        with(headers: token).
+        to_return(
           status: 200,
           body: fixture("github", "contents_pipeline_repo_custom.json"),
           headers: json_content_type
         )
 
-      stub_request(:get, File.join(url, "pipeline-template-base.yml?ref=sha"))
-        .with(headers: token)
-        .to_return(
+      stub_request(:get, File.join(url, "pipeline-template-base.yml?ref=sha")).
+        with(headers: token).
+        to_return(
           status: 200,
           body: fixture("github", "contents_pipeline.json"),
           headers: json_content_type
@@ -271,8 +271,8 @@ RSpec.describe Dependabot::Docker::FileFetcher do
 
     it "fetches the template file" do
       expect(file_fetcher_instance.files.count).to eq(1)
-      expect(file_fetcher_instance.files.map(&:name))
-        .to match_array(%w[pipeline-template-base.yml])
+      expect(file_fetcher_instance.files.map(&:name)).
+        to match_array(%w(pipeline-template-base.yml))
     end
   end
 
@@ -281,9 +281,9 @@ RSpec.describe Dependabot::Docker::FileFetcher do
     let(:directory) { "/non/existant" }
 
     before do
-      stub_request(:get, url + "non/existant?ref=sha")
-        .with(headers: token)
-        .to_return(
+      stub_request(:get, url + "non/existant?ref=sha").
+        with(headers: token).
+        to_return(
           status: 404,
           body: fixture("github", "not_found.json"),
           headers: json_content_type
@@ -291,25 +291,25 @@ RSpec.describe Dependabot::Docker::FileFetcher do
     end
 
     it "raises a helpful error" do
-      expect { file_fetcher_instance.files }
-        .to raise_error(Dependabot::DependencyFileNotFound)
+      expect { file_fetcher_instance.files }.
+        to raise_error(Dependabot::DependencyFileNotFound)
     end
   end
 
   context "with a docker-image-version file", :pix4d do
     it_behaves_like "a dependency file fetcher"
     before do
-      stub_request(:get, url + "?ref=sha")
-        .with(headers: token)
-        .to_return(
+      stub_request(:get, url + "?ref=sha").
+        with(headers: token).
+        to_return(
           status: 200,
           body: '[{"name": "docker-image-version.yml","type": "file"}]',
           headers: json_content_type
         )
 
-      stub_request(:get, File.join(url, "docker-image-version.yml?ref=sha"))
-        .with(headers: token)
-        .to_return(
+      stub_request(:get, File.join(url, "docker-image-version.yml?ref=sha")).
+        with(headers: token).
+        to_return(
           status: 200,
           body: '{
             "content": "RlJPTSB1YnVudHU6MTguMDQKCiMjIyBTWVNURU0gREVQRU5ERU5DSUVTCgoj\n",
@@ -321,8 +321,8 @@ RSpec.describe Dependabot::Docker::FileFetcher do
 
     it "fetches the template file" do
       expect(file_fetcher_instance.files.count).to eq(1)
-      expect(file_fetcher_instance.files.map(&:name))
-        .to match_array(%w[docker-image-version.yml])
+      expect(file_fetcher_instance.files.map(&:name)).
+        to match_array(%w(docker-image-version.yml))
     end
   end
 end

--- a/docker/spec/dependabot/docker/file_parser_spec.rb
+++ b/docker/spec/dependabot/docker/file_parser_spec.rb
@@ -636,11 +636,15 @@ RSpec.describe Dependabot::Docker::FileParser do
       end
     end
 
-    context "single yml file which contains no registry-image resources", :pix4d do
+    context "single yml file which contains no registry-image resources",
+            :pix4d do
       it_behaves_like "a dependency file parser"
       let(:file_name) { "no-registry.yml" }
       let(:dockerfile) do
-        Dependabot::DependencyFile.new(name: "#{file_name}-template", content: file_body)
+        Dependabot::DependencyFile.new(
+          name: "#{file_name}-template",
+          content: file_body
+        )
       end
       it "to be empty" do
         expect(dependencies).to be_empty
@@ -650,7 +654,10 @@ RSpec.describe Dependabot::Docker::FileParser do
     context "single yml file which contains a single resource", :pix4d do
       it_behaves_like "a dependency file parser"
       let(:dockerfile) do
-        Dependabot::DependencyFile.new(name: "#{file_name}-template", content: file_body)
+        Dependabot::DependencyFile.new(
+          name: "#{file_name}-template",
+          content: file_body
+        )
       end
       describe "with a simple public repository name" do
         let(:file_name) { "public-simple.yml" }
@@ -669,7 +676,7 @@ RSpec.describe Dependabot::Docker::FileParser do
           expect(dependency.version).to eq("1.0.7")
           expect(dependency.requirements).to eq(expected_requirements)
         end
-      end # describe
+      end
 
       describe "with a complex public repository name" do
         let(:file_name) { "public-complex.yml" }
@@ -688,7 +695,7 @@ RSpec.describe Dependabot::Docker::FileParser do
           expect(dependency.version).to eq("3.7.1")
           expect(dependency.requirements).to eq(expected_requirements)
         end
-      end # describe
+      end
 
       describe "from a private registry" do
         let(:file_name) { "private.yml" }
@@ -706,7 +713,7 @@ RSpec.describe Dependabot::Docker::FileParser do
           expect(dependency.version).to eq("20190620")
           expect(dependency.requirements).to eq(expected_requirements)
         end
-      end # describe
+      end
 
       describe "from a private registry (new tag format)" do
         let(:file_name) { "private.yml" }
@@ -724,14 +731,18 @@ RSpec.describe Dependabot::Docker::FileParser do
           expect(dependency.version).to eq("20190620150000")
           expect(dependency.requirements).to eq(expected_requirements)
         end
-      end # describe
-    end # context
+      end
+    end
 
-    context "single yml file which contains multiple (two) public resources", :pix4d do
+    context "single yml file which contains multiple (two) public resources",
+            :pix4d do
       it_behaves_like "a dependency file parser"
       let(:file_name) { "public-mix.yml" }
       let(:dockerfile) do
-        Dependabot::DependencyFile.new(name: "#{file_name}-template", content: file_body)
+        Dependabot::DependencyFile.new(
+          name: "#{file_name}-template",
+          content: file_body
+        )
       end
 
       describe "having a resource with single part repository name" do
@@ -766,14 +777,18 @@ RSpec.describe Dependabot::Docker::FileParser do
           expect(dependency.version).to eq("3.7.1")
           expect(dependency.requirements).to eq(expected_requirements)
         end
-      end # describe
-    end # context
+      end
+    end
 
-    context "single yml file which contains multiple resources (mix of private and public ones)", :pix4d do
+    context "single yml file which contains multiple resources \
+            (mix of private and public ones)", :pix4d do
       it_behaves_like "a dependency file parser"
       let(:file_name) { "mix.yml" }
       let(:dockerfile) do
-        Dependabot::DependencyFile.new(name: "#{file_name}-template", content: file_body)
+        Dependabot::DependencyFile.new(
+          name: "#{file_name}-template",
+          content: file_body
+        )
       end
 
       describe "having a resource with single part repository name" do
@@ -842,7 +857,7 @@ RSpec.describe Dependabot::Docker::FileParser do
           expect(dependency.version).to eq("20190620150000")
           expect(dependency.requirements).to eq(expected_requirements)
         end
-      end # describe
-    end # context
+      end
+    end
   end
 end

--- a/docker/spec/dependabot/docker/file_parser_spec.rb
+++ b/docker/spec/dependabot/docker/file_parser_spec.rb
@@ -811,7 +811,7 @@ RSpec.describe Dependabot::Docker::FileParser do
       end
 
       describe "having a resource with the tag format in YYYYMMDD" do
-        subject(:dependency) { dependencies[2]}
+        subject(:dependency) { dependencies[2] }
         let(:expected_requirements) do
           [{
             requirement: nil,
@@ -843,8 +843,6 @@ RSpec.describe Dependabot::Docker::FileParser do
           expect(dependency.requirements).to eq(expected_requirements)
         end
       end # describe
-
     end # context
-
   end
 end

--- a/docker/spec/dependabot/docker/file_updater_spec.rb
+++ b/docker/spec/dependabot/docker/file_updater_spec.rb
@@ -481,7 +481,8 @@ RSpec.describe Dependabot::Docker::FileUpdater do
     describe "#updated_dependency_files", :pix4d do
       it_behaves_like "a dependency file updater"
 
-      it "raises the correct error when 'dependency_files' do not contain any files or when 'dependency_files' is not a list" do
+      it "raises the correct error when 'dependency_files' do not contain \
+         any files or when 'dependency_files' is not a list" do
         expect do
           described_class.new(
             dependencies: nil,
@@ -590,7 +591,9 @@ RSpec.describe Dependabot::Docker::FileUpdater do
         updated_files = updater.updated_dependency_files
         updated_files.each { |f| expect(f).to be_a(Dependabot::DependencyFile) }
         expect(updated_files.first.name).to eq("private-complex.yml")
-        expect(updated_files.first.content).to include "private-image-name-16.04\n"
+        expect(
+          updated_files.first.content
+        ).to include "private-image-name-16.04\n"
         expect(updated_files.first.content).to include "tag: 20190825\n"
       end
 
@@ -635,7 +638,9 @@ RSpec.describe Dependabot::Docker::FileUpdater do
         updated_files = updater.updated_dependency_files
         updated_files.each { |f| expect(f).to be_a(Dependabot::DependencyFile) }
         expect(updated_files.first.name).to eq("private-complex.yml")
-        expect(updated_files.first.content).to include "private-image-name-16.04\n"
+        expect(
+          updated_files.first.content
+        ).to include "private-image-name-16.04\n"
         expect(updated_files.first.content).to include "tag: 20190825090000\n"
       end
 
@@ -679,11 +684,14 @@ RSpec.describe Dependabot::Docker::FileUpdater do
         updated_files = updater.updated_dependency_files
         updated_files.each { |f| expect(f).to be_a(Dependabot::DependencyFile) }
         expect(updated_files.first.name).to eq("pix4d-special.yml")
-        expect(updated_files.first.content).to include "private-image-name-16.04\n"
+        expect(
+          updated_files.first.content
+        ).to include "private-image-name-16.04\n"
         expect(updated_files.first.content).to include "tag: 20200308093045\n"
       end
 
-      it "correctly updates the input files if we use double quotes around tags" do
+      it "correctly updates the input files if we use double \
+         quotes around tags" do
         expected_requirements =
           [{
             requirement: nil,
@@ -722,11 +730,14 @@ RSpec.describe Dependabot::Docker::FileUpdater do
         updated_files = updater.updated_dependency_files
         updated_files.each { |f| expect(f).to be_a(Dependabot::DependencyFile) }
         expect(updated_files.first.name).to eq("pix4d-special.yml")
-        expect(updated_files.first.content).to include "private-image-name-18.04\n"
+        expect(
+          updated_files.first.content
+        ).to include "private-image-name-18.04\n"
         expect(updated_files.first.content).to include "tag: 20200309103030\n"
       end
 
-      it "correctly updates the input files if we use the bootstrapme tags with double quotes" do
+      it "correctly updates the input files if we use the bootstrapme \
+         tags with double quotes" do
         expected_requirements =
           [{
             requirement: nil,
@@ -770,5 +781,5 @@ RSpec.describe Dependabot::Docker::FileUpdater do
         expect(updated_files.first.content).to include "tag: 20200306093045\n"
       end
     end
-  end # describe updated_dependency_files
-end # RSpec.describe
+  end
+end

--- a/docker/spec/dependabot/docker/file_updater_spec.rb
+++ b/docker/spec/dependabot/docker/file_updater_spec.rb
@@ -478,301 +478,297 @@ RSpec.describe Dependabot::Docker::FileUpdater do
         end
       end
     end
-  describe "#updated_dependency_files",:pix4d do
-    it_behaves_like "a dependency file updater"
+    describe "#updated_dependency_files", :pix4d do
+      it_behaves_like "a dependency file updater"
 
-    it "raises the correct error when 'dependency_files' do not contain any files or when 'dependency_files' is not a list" do
-      expect do
-        described_class.new(
-          dependencies: nil,
-          dependency_files: [nil],
+      it "raises the correct error when 'dependency_files' do not contain any files or when 'dependency_files' is not a list" do
+        expect do
+          described_class.new(
+            dependencies: nil,
+            dependency_files: [nil],
+            credentials: nil
+          )
+        end .to raise_error("No file!")
+
+        expect do
+          described_class.new(
+            dependencies: nil,
+            dependency_files: nil,
+            credentials: nil
+          )
+        end .to raise_error("undefined method `any?' for nil:NilClass")
+      end
+
+      it "updates the input files" do
+        # expected output
+        expected_requirements =
+          [{
+            requirement: nil,
+            groups: [],
+            file: "public-simple.yml",
+            source: { tag: "1.10" }
+          }]
+
+        previous_requirements =
+          [{
+            requirement: nil,
+            groups: [],
+            file: "public-simple.yml",
+            source: { tag: "1.0.7" }
+          }]
+
+        # required input for the FileUpdater class
+        input_files = Dependabot::DependencyFile.new(
+          name: "public-simple.yml",
+          content: fixture("pipelines", "public-simple.yml")
+        )
+
+        input_dependencies = Dependabot::Dependency.new(
+          name: "public-image-name-1",
+          version: "1.10",
+          previous_version: "1.0.7",
+          requirements: expected_requirements,
+          previous_requirements: previous_requirements,
+          package_manager: "docker"
+        )
+
+        # call and instance to the FileUpdater class
+        updater = described_class.new(
+          dependencies: [input_dependencies],
+          dependency_files: [input_files],
           credentials: nil
         )
-      end .to raise_error("No file!")
 
-      expect do
-        described_class.new(
-          dependencies: nil,
-          dependency_files: nil,
+        updated_files = updater.updated_dependency_files
+        updated_files.each { |f| expect(f).to be_a(Dependabot::DependencyFile) }
+        expect(updated_files.first.name).to eq("public-simple.yml")
+        expect(updated_files.first.content).to include "public-image-name-1\n"
+        expect(updated_files.first.content).to include "tag: 1.10\n"
+      end
+
+      it "correctly updates the input files if we use the same number/string
+        in both the repository and tag" do
+        # expected output
+        expected_requirements =
+          [{
+            requirement: nil,
+            groups: [],
+            file: "private-complex.yml",
+            source: { tag: "20190825" }
+          }]
+
+        previous_requirements =
+          [{
+            requirement: nil,
+            groups: [],
+            file: "private-complex.yml",
+            source: { tag: "0" }
+          }]
+
+        # required input for the FileUpdater class
+        input_files = Dependabot::DependencyFile.new(
+          name: "private-complex.yml",
+          content: fixture("pipelines", "private-complex.yml")
+        )
+
+        input_dependencies = Dependabot::Dependency.new(
+          name: "private.repo.com/private-image-name-16.04",
+          version: "20190825",
+          previous_version: 0,
+          requirements: expected_requirements,
+          previous_requirements: previous_requirements,
+          package_manager: "docker"
+        )
+
+        # call and instance to the FileUpdater class
+        updater = described_class.new(
+          dependencies: [input_dependencies],
+          dependency_files: [input_files],
           credentials: nil
         )
-      end .to raise_error("undefined method `any?' for nil:NilClass")
+
+        updated_files = updater.updated_dependency_files
+        updated_files.each { |f| expect(f).to be_a(Dependabot::DependencyFile) }
+        expect(updated_files.first.name).to eq("private-complex.yml")
+        expect(updated_files.first.content).to include "private-image-name-16.04\n"
+        expect(updated_files.first.content).to include "tag: 20190825\n"
+      end
+
+      it "correctly updates the input files if we use the same number/string
+        in both the repository and tag (new tag format)" do
+        expected_requirements =
+          [{
+            requirement: nil,
+            groups: [],
+            file: "private-complex.yml",
+            source: { tag: "20190825090000" }
+          }]
+
+        expected_previous_requirements =
+          [{
+            requirement: nil,
+            groups: [],
+            file: "private-complex.yml",
+            source: { tag: "0" }
+          }]
+
+        input_files = Dependabot::DependencyFile.new(
+          name: "private-complex.yml",
+          content: fixture("pipelines", "private-complex.yml")
+        )
+
+        input_dependencies = Dependabot::Dependency.new(
+          name: "private.repo.com/private-image-name-16.04",
+          version: "20190825090000",
+          previous_version: 0,
+          requirements: expected_requirements,
+          previous_requirements: expected_previous_requirements,
+          package_manager: "docker"
+        )
+
+        updater = described_class.new(
+          dependencies: [input_dependencies],
+          dependency_files: [input_files],
+          credentials: nil
+        )
+
+        updated_files = updater.updated_dependency_files
+        updated_files.each { |f| expect(f).to be_a(Dependabot::DependencyFile) }
+        expect(updated_files.first.name).to eq("private-complex.yml")
+        expect(updated_files.first.content).to include "private-image-name-16.04\n"
+        expect(updated_files.first.content).to include "tag: 20190825090000\n"
+      end
+
+      it "correctly updates the input files if we use the bootstrapme tags" do
+        expected_requirements =
+          [{
+            requirement: nil,
+            groups: [],
+            file: "pix4d-special.yml",
+            source: { tag: "20200308093045" }
+          }]
+
+        expected_previous_requirements =
+          [{
+            requirement: nil,
+            groups: [],
+            file: "pix4d-special.yml",
+            source: { tag: "bootstrapme" }
+          }]
+
+        input_files = Dependabot::DependencyFile.new(
+          name: "pix4d-special.yml",
+          content: fixture("pipelines", "pix4d-special.yml")
+        )
+
+        input_dependencies = Dependabot::Dependency.new(
+          name: "private.repo.com/private-image-name-16.04",
+          version: "20200308093045",
+          previous_version: "bootstrapme",
+          requirements: expected_requirements,
+          previous_requirements: expected_previous_requirements,
+          package_manager: "docker"
+        )
+
+        updater = described_class.new(
+          dependencies: [input_dependencies],
+          dependency_files: [input_files],
+          credentials: nil
+        )
+
+        updated_files = updater.updated_dependency_files
+        updated_files.each { |f| expect(f).to be_a(Dependabot::DependencyFile) }
+        expect(updated_files.first.name).to eq("pix4d-special.yml")
+        expect(updated_files.first.content).to include "private-image-name-16.04\n"
+        expect(updated_files.first.content).to include "tag: 20200308093045\n"
+      end
+
+      it "correctly updates the input files if we use double quotes around tags" do
+        expected_requirements =
+          [{
+            requirement: nil,
+            groups: [],
+            file: "pix4d-special.yml",
+            source: { tag: "20200309103030" }
+          }]
+
+        expected_previous_requirements =
+          [{
+            requirement: nil,
+            groups: [],
+            file: "pix4d-special.yml",
+            source: { tag: "20200220151020" }
+          }]
+
+        input_files = Dependabot::DependencyFile.new(
+          name: "pix4d-special.yml",
+          content: fixture("pipelines", "pix4d-special.yml")
+        )
+
+        input_dependencies = Dependabot::Dependency.new(
+          name: "private.repo.com/private-image-name-18.04",
+          version: "20200309103030",
+          previous_version: "20200220151020",
+          requirements: expected_requirements,
+          previous_requirements: expected_previous_requirements,
+          package_manager: "docker"
+        )
+        updater = described_class.new(
+          dependencies: [input_dependencies],
+          dependency_files: [input_files],
+          credentials: nil
+        )
+
+        updated_files = updater.updated_dependency_files
+        updated_files.each { |f| expect(f).to be_a(Dependabot::DependencyFile) }
+        expect(updated_files.first.name).to eq("pix4d-special.yml")
+        expect(updated_files.first.content).to include "private-image-name-18.04\n"
+        expect(updated_files.first.content).to include "tag: 20200309103030\n"
+      end
+
+      it "correctly updates the input files if we use the bootstrapme tags with double quotes" do
+        expected_requirements =
+          [{
+            requirement: nil,
+            groups: [],
+            file: "pix4d-special.yml",
+            source: { tag: "20200306093045" }
+          }]
+
+        expected_previous_requirements =
+          [{
+            requirement: nil,
+            groups: [],
+            file: "pix4d-special.yml",
+            source: { tag: "bootstrapme" }
+          }]
+
+        input_files = Dependabot::DependencyFile.new(
+          name: "pix4d-special.yml",
+          content: fixture("pipelines", "pix4d-special.yml")
+        )
+
+        input_dependencies = Dependabot::Dependency.new(
+          name: "private.repo.com/private-image-name",
+          version: "20200306093045",
+          previous_version: "bootstrapme",
+          requirements: expected_requirements,
+          previous_requirements: expected_previous_requirements,
+          package_manager: "docker"
+        )
+
+        updater = described_class.new(
+          dependencies: [input_dependencies],
+          dependency_files: [input_files],
+          credentials: nil
+        )
+
+        updated_files = updater.updated_dependency_files
+        updated_files.each { |f| expect(f).to be_a(Dependabot::DependencyFile) }
+        expect(updated_files.first.name).to eq("pix4d-special.yml")
+        expect(updated_files.first.content).to include "private-image-name\n"
+        expect(updated_files.first.content).to include "tag: 20200306093045\n"
+      end
     end
-
-    it "updates the input files"  do
-      # expected output
-      expected_requirements =
-        [{
-          requirement: nil,
-          groups: [],
-          file: "public-simple.yml",
-          source: { tag: "1.10" }
-        }]
-
-      previous_requirements =
-        [{
-          requirement: nil,
-          groups: [],
-          file: "public-simple.yml",
-          source: { tag: "1.0.7" }
-        }]
-
-      # required input for the FileUpdater class
-      input_files = Dependabot::DependencyFile.new(
-        name: "public-simple.yml",
-        content: fixture("pipelines", "public-simple.yml")
-      )
-
-      input_dependencies = Dependabot::Dependency.new(
-        name: "public-image-name-1",
-        version: "1.10",
-        previous_version: "1.0.7",
-        requirements: expected_requirements,
-        previous_requirements: previous_requirements,
-        package_manager: "docker"
-      )
-
-      # call and instance to the FileUpdater class
-      updater = described_class.new(
-        dependencies: [input_dependencies],
-        dependency_files: [input_files],
-        credentials: nil
-      )
-
-      updated_files = updater.updated_dependency_files
-      updated_files.each { |f| expect(f).to be_a(Dependabot::DependencyFile) }
-      expect(updated_files.first.name).to eq("public-simple.yml")
-      expect(updated_files.first.content).to include "public-image-name-1\n"
-      expect(updated_files.first.content).to include "tag: 1.10\n"
-    end
-
-    it "correctly updates the input files if we use the same number/string
-        in both the repository and tag"  do
-      # expected output
-      expected_requirements =
-        [{
-          requirement: nil,
-          groups: [],
-          file: "private-complex.yml",
-          source: { tag: "20190825" }
-        }]
-
-      previous_requirements =
-        [{
-          requirement: nil,
-          groups: [],
-          file: "private-complex.yml",
-          source: { tag: "0" }
-        }]
-
-      # required input for the FileUpdater class
-      input_files = Dependabot::DependencyFile.new(
-        name: "private-complex.yml",
-        content: fixture("pipelines", "private-complex.yml")
-      )
-
-      input_dependencies = Dependabot::Dependency.new(
-        name: "private.repo.com/private-image-name-16.04",
-        version: "20190825",
-        previous_version: 0,
-        requirements: expected_requirements,
-        previous_requirements: previous_requirements,
-        package_manager: "docker"
-      )
-
-      # call and instance to the FileUpdater class
-      updater = described_class.new(
-        dependencies: [input_dependencies],
-        dependency_files: [input_files],
-        credentials: nil
-      )
-
-      updated_files = updater.updated_dependency_files
-      updated_files.each { |f| expect(f).to be_a(Dependabot::DependencyFile) }
-      expect(updated_files.first.name).to eq("private-complex.yml")
-      expect(updated_files.first.content).to include "private-image-name-16.04\n"
-      expect(updated_files.first.content).to include "tag: 20190825\n"
-    end
-
-    it "correctly updates the input files if we use the same number/string
-        in both the repository and tag (new tag format)"  do
-
-      expected_requirements =
-        [{
-          requirement: nil,
-          groups: [],
-          file: "private-complex.yml",
-          source: { tag: "20190825090000" }
-        }]
-
-      expected_previous_requirements =
-        [{
-          requirement: nil,
-          groups: [],
-          file: "private-complex.yml",
-          source: { tag: "0" }
-        }]
-
-      input_files = Dependabot::DependencyFile.new(
-        name: "private-complex.yml",
-        content: fixture("pipelines", "private-complex.yml")
-      )
-
-      input_dependencies = Dependabot::Dependency.new(
-        name: "private.repo.com/private-image-name-16.04",
-        version: "20190825090000",
-        previous_version: 0,
-        requirements: expected_requirements,
-        previous_requirements: expected_previous_requirements,
-        package_manager: "docker"
-      )
-
-      updater = described_class.new(
-        dependencies: [input_dependencies],
-        dependency_files: [input_files],
-        credentials: nil
-      )
-
-      updated_files = updater.updated_dependency_files
-      updated_files.each { |f| expect(f).to be_a(Dependabot::DependencyFile) }
-      expect(updated_files.first.name).to eq("private-complex.yml")
-      expect(updated_files.first.content).to include "private-image-name-16.04\n"
-      expect(updated_files.first.content).to include "tag: 20190825090000\n"
-    end
-
-    it "correctly updates the input files if we use the bootstrapme tags"  do
-
-      expected_requirements =
-        [{
-          requirement: nil,
-          groups: [],
-          file: "pix4d-special.yml",
-          source: { tag: "20200308093045" }
-        }]
-
-      expected_previous_requirements =
-        [{
-          requirement: nil,
-          groups: [],
-          file: "pix4d-special.yml",
-          source: { tag: "bootstrapme" }
-        }]
-
-      input_files = Dependabot::DependencyFile.new(
-        name: "pix4d-special.yml",
-        content: fixture("pipelines", "pix4d-special.yml")
-      )
-
-      input_dependencies = Dependabot::Dependency.new(
-        name: "private.repo.com/private-image-name-16.04",
-        version: "20200308093045",
-        previous_version: "bootstrapme",
-        requirements: expected_requirements,
-        previous_requirements: expected_previous_requirements,
-        package_manager: "docker"
-      )
-
-      updater = described_class.new(
-        dependencies: [input_dependencies],
-        dependency_files: [input_files],
-        credentials: nil
-      )
-
-      updated_files = updater.updated_dependency_files
-      updated_files.each { |f| expect(f).to be_a(Dependabot::DependencyFile) }
-      expect(updated_files.first.name).to eq("pix4d-special.yml")
-      expect(updated_files.first.content).to include "private-image-name-16.04\n"
-      expect(updated_files.first.content).to include "tag: 20200308093045\n"
-  end
-
-  it "correctly updates the input files if we use double quotes around tags"  do
-
-    expected_requirements =
-      [{
-        requirement: nil,
-        groups: [],
-        file: "pix4d-special.yml",
-        source: { tag: "20200309103030" }
-      }]
-
-    expected_previous_requirements =
-      [{
-        requirement: nil,
-        groups: [],
-        file: "pix4d-special.yml",
-        source: { tag: "20200220151020" }
-      }]
-
-    input_files = Dependabot::DependencyFile.new(
-      name: "pix4d-special.yml",
-      content: fixture("pipelines", "pix4d-special.yml")
-    )
-
-    input_dependencies = Dependabot::Dependency.new(
-      name: "private.repo.com/private-image-name-18.04",
-      version: "20200309103030",
-      previous_version: "20200220151020",
-      requirements: expected_requirements,
-      previous_requirements: expected_previous_requirements,
-      package_manager: "docker"
-    )
-    updater = described_class.new(
-      dependencies: [input_dependencies],
-      dependency_files: [input_files],
-      credentials: nil
-    )
-
-    updated_files = updater.updated_dependency_files
-    updated_files.each { |f| expect(f).to be_a(Dependabot::DependencyFile) }
-    expect(updated_files.first.name).to eq("pix4d-special.yml")
-    expect(updated_files.first.content).to include "private-image-name-18.04\n"
-    expect(updated_files.first.content).to include "tag: 20200309103030\n"
-  end
-
-  it "correctly updates the input files if we use the bootstrapme tags with double quotes"  do
-
-    expected_requirements =
-      [{
-        requirement: nil,
-        groups: [],
-        file: "pix4d-special.yml",
-        source: { tag: "20200306093045" }
-      }]
-
-    expected_previous_requirements =
-      [{
-        requirement: nil,
-        groups: [],
-        file: "pix4d-special.yml",
-        source: { tag: "bootstrapme" }
-      }]
-
-    input_files = Dependabot::DependencyFile.new(
-      name: "pix4d-special.yml",
-      content: fixture("pipelines", "pix4d-special.yml")
-    )
-
-    input_dependencies = Dependabot::Dependency.new(
-      name: "private.repo.com/private-image-name",
-      version: "20200306093045",
-      previous_version: "bootstrapme",
-      requirements: expected_requirements,
-      previous_requirements: expected_previous_requirements,
-      package_manager: "docker"
-    )
-
-    updater = described_class.new(
-      dependencies: [input_dependencies],
-      dependency_files: [input_files],
-      credentials: nil
-    )
-
-    updated_files = updater.updated_dependency_files
-    updated_files.each { |f| expect(f).to be_a(Dependabot::DependencyFile) }
-    expect(updated_files.first.name).to eq("pix4d-special.yml")
-    expect(updated_files.first.content).to include "private-image-name\n"
-    expect(updated_files.first.content).to include "tag: 20200306093045\n"
-end
-end
-end# describe updated_dependency_files
+  end # describe updated_dependency_files
 end # RSpec.describe

--- a/docker/spec/dependabot/docker/update_checker_spec.rb
+++ b/docker/spec/dependabot/docker/update_checker_spec.rb
@@ -659,11 +659,11 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
     end
   end
 
-  describe "Pix4D tests", :pix4d  do
+  describe "Pix4D tests", :pix4d do
     describe "Method #can_update?" do
       before do
-        stub_request(:get, "https://registry.hub.docker.com/v2/library/#{dependency_name}/tags/list")
-          .and_return(
+        stub_request(:get, "https://registry.hub.docker.com/v2/library/#{dependency_name}/tags/list").
+          and_return(
             status: 200,
             body: { "name": "library/#{dependency_name}", "tags": ["20200310162045"] }.to_json
           )
@@ -709,10 +709,10 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
       end
     end
 
-    describe "Method #up_to_date?"  do
+    describe "Method #up_to_date?" do
       before do
-        stub_request(:get, "https://registry.hub.docker.com/v2/library/#{dependency_name}/tags/list")
-          .and_return(
+        stub_request(:get, "https://registry.hub.docker.com/v2/library/#{dependency_name}/tags/list").
+          and_return(
             status: 200,
             body: { "name": "library/#{dependency_name}", "tags": ["20200315081015"] }.to_json
           )
@@ -764,8 +764,8 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
 
       context "return latest tag" do
         before do
-          stub_request(:get, "https://registry.hub.docker.com/v2/library/#{dependency_name}/tags/list")
-            .and_return(
+          stub_request(:get, "https://registry.hub.docker.com/v2/library/#{dependency_name}/tags/list").
+            and_return(
               status: 200,
               body: { "name": "library/#{dependency_name}", "tags": ["20200320091510"] }.to_json
             )
@@ -776,44 +776,44 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
 
       context "every time public docker registry times out" do
         before do
-          stub_request(:get, "https://registry.hub.docker.com/v2/library/#{dependency_name}/tags/list")
-            .to_raise(RestClient::Exceptions::OpenTimeout)
+          stub_request(:get, "https://registry.hub.docker.com/v2/library/#{dependency_name}/tags/list").
+            to_raise(RestClient::Exceptions::OpenTimeout)
         end
 
         it "raises" do
-          expect { checker.latest_version }
-            .to raise_error(RestClient::Exceptions::OpenTimeout)
+          expect { checker.latest_version }.
+            to raise_error(RestClient::Exceptions::OpenTimeout)
         end
       end
 
       context "every time private docker registry times out" do
         before do
-          stub_request(:get, "https://registry-host.io:5000/v2/#{dependency_name}/tags/list")
-            .to_raise(RestClient::Exceptions::OpenTimeout)
+          stub_request(:get, "https://registry-host.io:5000/v2/#{dependency_name}/tags/list").
+            to_raise(RestClient::Exceptions::OpenTimeout)
         end
 
         let(:source) { { registry: "registry-host.io:5000" } }
 
         it "raises" do
-          expect { checker.latest_version }
-            .to raise_error(Dependabot::PrivateSourceTimedOut)
+          expect { checker.latest_version }.
+            to raise_error(Dependabot::PrivateSourceTimedOut)
         end
       end
 
       context "without authentication credentials" do
         before do
-          stub_request(:get, "https://registry-host.io:5000/v2/#{dependency_name}/tags/list")
-            .and_return(
+          stub_request(:get, "https://registry-host.io:5000/v2/#{dependency_name}/tags/list").
+            and_return(
               status: 401,
               body: "",
-              headers: { 'www_authenticate' => 'basic 123' }
+              headers: { "www_authenticate" => "basic 123" }
             )
         end
         let(:source) { { registry: "registry-host.io:5000" } }
 
         it "raises a to PrivateSourceAuthenticationFailure error" do
-          expect { checker.latest_version }
-            .to raise_error(Dependabot::PrivateSourceAuthenticationFailure) do |error|
+          expect { checker.latest_version }.
+            to raise_error(Dependabot::PrivateSourceAuthenticationFailure) do |error|
               expect(error.source).to eq("registry-host.io:5000")
             end
         end
@@ -822,20 +822,20 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
       context "connects to private registry with authentication credentials and returns" do
         let(:credentials) do
           [{
-            'type' => 'docker_registry',
-            'registry' => 'registry-host.io:5000',
-            'username' => 'user',
-            'password' => 'pa55word'
+            "type" => "docker_registry",
+            "registry" => "registry-host.io:5000",
+            "username" => "user",
+            "password" => "pa55word"
           }]
         end
         let(:source) { { registry: "registry-host.io:5000" } }
 
         before do
           tags_url = "https://registry-host.io:5000/v2/#{dependency_name}/tags/list"
-          stub_request(:get, tags_url)
-            .and_return(
+          stub_request(:get, tags_url).
+            and_return(
               status: 200,
-              body: { "name": "library/#{dependency_name}", "tags": ["bootstrapme","20190220091510","20200220091510","20200320091510"] }.to_json
+              body: { "name": "library/#{dependency_name}", "tags": %w(bootstrapme 20190220091510 20200220091510 20200320091510) }.to_json
             )
         end
 
@@ -845,17 +845,17 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
       context "connects to public registry and returns" do
         let(:credentials) do
           [{
-            'type' => 'docker_registry',
-            'registry' => 'registry-host.io:5000'
+            "type" => "docker_registry",
+            "registry" => "registry-host.io:5000"
           }]
         end
 
         before do
           tags_url = "https://registry.hub.docker.com/v2/library/#{dependency_name}/tags/list"
-          stub_request(:get, tags_url)
-            .and_return(
+          stub_request(:get, tags_url).
+            and_return(
               status: 200,
-              body: { "name": "library/#{dependency_name}", "tags": ["20190220","20200302","20200320091510"] }.to_json
+              body: { "name": "library/#{dependency_name}", "tags": %w(20190220 20200302 20200320091510) }.to_json
             )
         end
 
@@ -870,21 +870,22 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
           stub_request(:get, "https://registry.hub.docker.com/v2/library/#{dependency_name}/tags/list").
             and_return(
               status: 200,
-              body: { "name": "library/#{dependency_name}", "tags": ["20200301","20200302","latest","20200320091510"] }.to_json
+              body: { "name": "library/#{dependency_name}", "tags": %w(20200301 20200302 latest 20200320091510) }.to_json
             )
           stub_request(:head, "https://registry.hub.docker.com/v2/library/#{dependency_name}/manifests/latest").
             and_return(
               status: 200,
-              headers: JSON.parse('{"docker_content_digest":"sha256:123"}'))
+              headers: JSON.parse('{"docker_content_digest":"sha256:123"}')
+            )
           stub_request(:head, "https://registry.hub.docker.com/v2/library/#{dependency_name}/manifests/20200320091510").
             and_return(
               status: 200,
-              headers: JSON.parse('{"docker_content_digest":"sha256:123"}'))
+              headers: JSON.parse('{"docker_content_digest":"sha256:123"}')
+            )
         end
 
         it { is_expected.to eq("20200320091510") }
       end
-
     end
 
     describe "Method #updated_requirements"  do
@@ -908,10 +909,10 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
 
       before do
         tags_url = "https://registry.hub.docker.com/v2/library/#{dependency_name}/tags/list"
-        stub_request(:get, tags_url)
-          .and_return(
+        stub_request(:get, tags_url).
+          and_return(
             status: 200,
-            body: { "name": "library/#{dependency_name}", "tags": ["bootstrapme","20190220091510","20200220091510","20200320091510"] }.to_json
+            body: { "name": "library/#{dependency_name}", "tags": %w(bootstrapme 20190220091510 20200220091510 20200320091510) }.to_json
           )
       end
 
@@ -919,8 +920,8 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
         let(:version) { "bootstrapme" }
 
         it "updates the bootstrapme tag" do
-          expect(checker.updated_requirements)
-            .to eq(
+          expect(checker.updated_requirements).
+            to eq(
               [{
                 requirement: nil,
                 groups: [],
@@ -935,8 +936,8 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
         let(:version) { "0" }
 
         it "updates the tag" do
-          expect(checker.updated_requirements)
-            .to eq(
+          expect(checker.updated_requirements).
+            to eq(
               [{
                 requirement: nil,
                 groups: [],
@@ -951,8 +952,8 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
         let(:version) { "20190101" }
 
         it "updates the tag" do
-          expect(checker.updated_requirements)
-            .to eq(
+          expect(checker.updated_requirements).
+            to eq(
               [{
                 requirement: nil,
                 groups: [],
@@ -962,8 +963,6 @@ RSpec.describe Dependabot::Docker::UpdateChecker do
             )
         end
       end
-
     end
-
   end
 end

--- a/docker/spec/dependabot/docker/utils/credentials_finder_spec.rb
+++ b/docker/spec/dependabot/docker/utils/credentials_finder_spec.rb
@@ -18,12 +18,12 @@ RSpec.describe Dependabot::Docker::Utils::CredentialsFinder do
     subject(:found_credentials) { finder.credentials_for_registry(registry) }
     let(:registry) { "my.registry.com" }
 
-    context "with no matching credentials", :pix4d  do
+    context "with no matching credentials", :pix4d do
       let(:registry) { "my.registry.com" }
       it { is_expected.to be_nil }
     end
 
-    context "with a non-AWS registry", :pix4d  do
+    context "with a non-AWS registry", :pix4d do
       let(:registry) { "my.registry.com" }
       let(:credentials) do
         [{

--- a/docker/spec/pr_info_spec.rb
+++ b/docker/spec/pr_info_spec.rb
@@ -5,10 +5,10 @@ require "dependabot/dependency"
 
 def make_dependency_with_registry(registry)
   requirement = {
-    :requirement => nil,
-    :groups => [],
-    :file => "",
-    :source => {}
+    requirement: nil,
+    groups: [],
+    file: "",
+    source: {}
   }
 
   requirement[:source][:registry] = registry unless registry.nil?
@@ -17,23 +17,24 @@ def make_dependency_with_registry(registry)
     name: "python",
     version: "3.8.0",
     requirements: [requirement],
-    package_manager: nil)
+    package_manager: nil
+  )
 end
 
-RSpec.describe "pr_info", :pix4d  do
+RSpec.describe "pr_info", :pix4d do
   context "using a private registry" do
     it "links to Pix4D image builder repo" do
       dependency = make_dependency_with_registry("docker.ci.pix4d.com")
-      expect(pr_info(dependency))
-        .to include("https://github.com/Pix4D/linux-image-build/releases/tag/python-3.8.0")
+      expect(pr_info(dependency)).
+        to include("https://github.com/Pix4D/linux-image-build/releases/tag/python-3.8.0")
     end
   end
 
   context "using a public registry" do
     it "links to DockerHub search page" do
       dependency = make_dependency_with_registry(nil)
-      expect(pr_info(dependency))
-        .to include("https://hub.docker.com/_/python?tab=tags&name=3.8.0")
+      expect(pr_info(dependency)).
+        to include("https://hub.docker.com/_/python?tab=tags&name=3.8.0")
     end
   end
 end

--- a/docker/spec/pr_info_spec.rb
+++ b/docker/spec/pr_info_spec.rb
@@ -1,5 +1,4 @@
-# frozen_string_literal: true
-
+# rubocop:disable Style/FrozenStringLiteralComment
 require "dependabot/pr_info"
 require "dependabot/dependency"
 
@@ -26,7 +25,9 @@ RSpec.describe "pr_info", :pix4d do
     it "links to Pix4D image builder repo" do
       dependency = make_dependency_with_registry("docker.ci.pix4d.com")
       expect(pr_info(dependency)).
-        to include("https://github.com/Pix4D/linux-image-build/releases/tag/python-3.8.0")
+        to include(
+          "https://github.com/Pix4D/linux-image-build/releases/tag/python-3.8.0"
+        )
     end
   end
 
@@ -38,3 +39,4 @@ RSpec.describe "pr_info", :pix4d do
     end
   end
 end
+# rubocop:enable Style/FrozenStringLiteralComment


### PR DESCRIPTION
First commit contains the style changes rubocop could do automatically.
Second and third commit contains the modification of the code to comply with rubocop settings.

`Rubocop` output on the repository:
```
Inspecting 657 files

657 files inspected, no offenses detected
```
`bundle exec rspec` output from docker folder:
```
Finished in 1.91 seconds (files took 0.68916 seconds to load)
253 examples, 0 failures
```