### PR TITLE
PCI-1067 Rescue when feature branch is deleted automatically

### DIFF
--- a/docker/dependabot-main.rb
+++ b/docker/dependabot-main.rb
@@ -60,7 +60,12 @@ def auto_merge(pull_req)
     raise "The PR was not merged correctly"
   end
 
-  client.delete_branch(ENV["PROJECT_PATH"], pull_req.head.ref)
+  # Delete the branch if it exists. If it doesn't exist, swallow the exception.
+  begin
+    client.delete_branch(ENV["PROJECT_PATH"], pull_req.head.ref)
+  rescue Octokit::UnprocessableEntity
+    nil
+  end
 end
 
 credentials_github =


### PR DESCRIPTION
- if feature branch is deleted automatically by Github auto_merge function would raise an error
- rescue in case when featrure branch was already deleted

Fixes the following error occurring for repositories which automatically delete the HEAD branch after merging the PR :
``` 
DELETE https://api.github.com/repos/Pix4D/linux-image-build/git/refs/heads/docker-dockerfiles-conan-dockerfiles-conan-builder-ubuntu-18.04-cuda-10.1-master-conan-builder-ubuntu-18.04-20200327152450: 
422 - Reference does not exist // See: https://developer.github.com/v3/git/refs/#delete-a-reference (Octokit::UnprocessableEntity)
```
https://builder.ci.pix4d.com/teams/main/pipelines/github-automation-master/jobs/dependabot-docker-linux-image-build/builds/181