### PR TITLE
Reorganize helpers functions

### DIFF
--- a/docker/lib/dependabot/auto_merge.rb
+++ b/docker/lib/dependabot/auto_merge.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# Automatically merge a pull request to update base Docker image
+# for Dockerfiles found in linux-image-build repository
+def auto_merge(pr_number,
+               pr_branch,
+               project_path,
+               feature_package,
+               github_token)
+
+  return unless feature_package == "docker"
+
+  commit_title = "[Dependabot Docker] Update base Docker image (automerged)"
+  client = Octokit::Client.new(access_token: github_token)
+  client.merge_pull_request(
+    project_path,
+    pr_number,
+    "Update base Docker image",
+    commit_title: commit_title
+  )
+
+  unless client.pull_merged?(project_path, pr_number)
+    raise "The PR was not merged correctly"
+  end
+
+  # Delete the branch if it exists. If it doesn't exist, swallow the exception.
+  begin
+    client.delete_branch(project_path, pr_branch)
+  rescue Octokit::UnprocessableEntity
+    nil
+  end
+end

--- a/docker/spec/auto_merge_spec.rb
+++ b/docker/spec/auto_merge_spec.rb
@@ -1,0 +1,75 @@
+require "dependabot/auto_merge"
+require "spec_helper"
+# frozen_string_literal: true
+
+RSpec.describe "auto_merge", :pix4d do
+  it "returns nil if feature package is not set to docker" do
+    expect(auto_merge("", "", "", "concourse", "")).to be_nil
+  end
+
+  context "using a docker feature_package" do
+    let(:github_url) { "https://api.github.com/" }
+    let(:url_1) do
+      github_url +
+        "repos/#{project_path}/pulls/#{pr_number}/merge"
+    end
+    let(:project_path) { "Pix4D/dependabot" }
+    let(:pr_number) { "101" }
+
+    before do
+      stub_request(:put, url_1).
+        to_return(
+          status: 200,
+          body: { "merged": true }.to_json,
+          headers: { "content-type" => "application/json" }
+        )
+      stub_request(:get, url_1).
+        to_return(
+          status: 404
+        )
+    end
+
+    it "raises if the PR is not merged correctly" do
+      expect do
+        auto_merge(pr_number, "feature-branch", project_path, "docker", "token")
+      end.to raise_error(RuntimeError, "The PR was not merged correctly")
+    end
+  end
+
+  context "using a docker feature_package" do
+    let(:github_url) { "https://api.github.com/" }
+    let(:url_1) do
+      github_url +
+        "repos/#{project_path}/pulls/#{pr_number}/merge"
+    end
+    let(:url_2) do
+      github_url +
+        "repos/#{project_path}/git/refs/heads/#{pr_branch}"
+    end
+    let(:project_path) { "Pix4D/dependabot" }
+    let(:pr_number) { "101" }
+    let(:pr_branch) { "feature-branch" }
+
+    before do
+      stub_request(:put, url_1).
+        to_return(
+          status: 200,
+          body: { "merged": true }.to_json,
+          headers: { "content-type" => "application/json" }
+        )
+      stub_request(:get, url_1).
+        to_return(
+          status: 204
+        )
+      stub_request(:delete, url_2).
+        to_return(
+          status: 422
+        )
+    end
+
+    it "returns nil if the branch was already deleted" do
+      expect(auto_merge(pr_number, pr_branch, project_path, "docker", "token")).
+        to be_nil
+    end
+  end
+end

--- a/docker/spec/path_level_spec.rb
+++ b/docker/spec/path_level_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require "dependabot/path_level"
+require "spec_helper"
+
+RSpec.describe "recursive_path", :pix4d do
+  context "using a concourse feature_package" do
+    it "returns the correct project_path" do
+      expect(recursive_path(
+               "concourse",
+               "Pix4D/dependabot",
+               "ci/pipelines",
+               "token"
+             )).to eq(["ci/pipelines"])
+    end
+  end
+
+  context "using a docker feature_package" do
+    let(:github_url) { "https://api.github.com/" }
+    let(:url_1) { github_url + "repos/#{project_path}/branches/master" }
+    let(:url_2) do
+      github_url +
+        "repos/#{project_path}/git/trees/#{github_sha}?recursive=true"
+    end
+    let(:project_path) { "Pix4D/dependabot" }
+    let(:dependency_dir) { "dockerfiles" }
+    let(:github_sha) { "76abc" }
+
+    before do
+      stub_request(:get, url_1).
+        to_return(
+          status: 200,
+          body: { "name": "master", "commit": { "sha": github_sha } }.to_json,
+          headers: { "content-type" => "application/json" }
+        )
+      stub_request(:get, url_2).
+        to_return(
+          status: 200,
+          body: { "sha": github_sha, "tree": [
+            { "path": "dockerfiles/folder-1/Dockerfile" },
+            { "path": "dockerfiles/folder-2/Dockerfile" },
+            { "path": "dockerfiles/folder-2/code.py" },
+            { "path": "ci/pipeline-template.ymls" }
+          ] }.to_json,
+          headers: { "content-type" => "application/json" }
+        )
+    end
+
+    it "returns the correct project_path" do
+      expect(recursive_path("docker", project_path, dependency_dir, "token")).
+        to eq(["dockerfiles/folder-1", "dockerfiles/folder-2"])
+    end
+  end
+
+  context "using a docker feature_package" do
+    let(:github_url) { "https://api.github.com/" }
+    let(:url_1) { github_url + "repos/#{project_path}/branches/master" }
+    let(:project_path) { "Pix4D/non-existing" }
+
+    before do
+      stub_request(:get, url_1).
+        to_return(
+          status: 404,
+          body: { "message": "not found" }.to_json,
+          headers: { "content-type" => "application/json" }
+        )
+    end
+
+    it "raises a correct error (repo not found)" do
+      expect { recursive_path("docker", project_path, "path", "token") }.
+        to raise_error(Octokit::NotFound, "GET #{url_1}: 404 - not found")
+    end
+  end
+
+  context "using a docker feature_package" do
+    let(:github_url) { "https://api.github.com/" }
+    let(:url_1) { github_url + "repos/#{project_path}/branches/master" }
+    let(:url_2) do
+      github_url +
+        "repos/#{project_path}/git/trees/#{github_sha}?recursive=true"
+    end
+    let(:project_path) { "Pix4D/dependabot" }
+    let(:dependency_dir) { "dockerfiles" }
+    let(:github_sha) { "76abc" }
+
+    before do
+      stub_request(:get, url_1).
+        to_return(
+          status: 200,
+          body: { "name": "master", "commit": { "sha": github_sha } }.to_json,
+          headers: { "content-type" => "application/json" }
+        )
+      stub_request(:get, url_2).
+        to_return(
+          status: 404,
+          body: { "message": "not found" }.to_json,
+          headers: { "content-type" => "application/json" }
+        )
+    end
+
+    it "raises a correct error (tree not found)" do
+      expect { recursive_path("docker", project_path, "path", "token") }.
+        to raise_error(Octokit::NotFound, "GET #{url_2}: 404 - not found")
+    end
+  end
+end


### PR DESCRIPTION
- pr_info, recursive_path and auto_merge are now part of `helpers_functions.rb`
- enables us to write tests for these functions and reduces the amount of files