### PR TITLE
Fix the error when pull_request is nil

### DIFF
--- a/docker/dependabot-main.rb
+++ b/docker/dependabot-main.rb
@@ -114,13 +114,14 @@ input_files_path.each do |file_path|
 
     pull_request = pr.create
 
-    puts pull_request.html_url
+    puts pull_request.html_url if pull_request
 
-    auto_merge(pull_request.number,
-               pull_request.head.ref,
-               ENV["PROJECT_PATH"],
-               ENV["FEATURE_PACKAGE"],
-               ENV["GITHUB_ACCESS_TOKEN"])
+    if ENV["FEATURE_PACKAGE"] == "docker"
+      auto_merge(pull_request.number,
+                 pull_request.head.ref,
+                 ENV["PROJECT_PATH"],
+                 ENV["GITHUB_ACCESS_TOKEN"])
+    end
 
     next unless pull_request
   end

--- a/docker/lib/dependabot/auto_merge.rb
+++ b/docker/lib/dependabot/auto_merge.rb
@@ -5,10 +5,7 @@
 def auto_merge(pr_number,
                pr_branch,
                project_path,
-               feature_package,
                github_token)
-
-  return unless feature_package == "docker"
 
   commit_title = "[Dependabot Docker] Update base Docker image (automerged)"
   client = Octokit::Client.new(access_token: github_token)

--- a/docker/spec/auto_merge_spec.rb
+++ b/docker/spec/auto_merge_spec.rb
@@ -3,10 +3,6 @@ require "spec_helper"
 # frozen_string_literal: true
 
 RSpec.describe "auto_merge", :pix4d do
-  it "returns nil if feature package is not set to docker" do
-    expect(auto_merge("", "", "", "concourse", "")).to be_nil
-  end
-
   context "using a docker feature_package" do
     let(:github_url) { "https://api.github.com/" }
     let(:url_1) do
@@ -31,7 +27,7 @@ RSpec.describe "auto_merge", :pix4d do
 
     it "raises if the PR is not merged correctly" do
       expect do
-        auto_merge(pr_number, "feature-branch", project_path, "docker", "token")
+        auto_merge(pr_number, "feature-branch", project_path, "token")
       end.to raise_error(RuntimeError, "The PR was not merged correctly")
     end
   end
@@ -68,7 +64,7 @@ RSpec.describe "auto_merge", :pix4d do
     end
 
     it "returns nil if the branch was already deleted" do
-      expect(auto_merge(pr_number, pr_branch, project_path, "docker", "token")).
+      expect(auto_merge(pr_number, pr_branch, project_path, "token")).
         to be_nil
     end
   end


### PR DESCRIPTION
- pull_request.html_url raises undefined method `html_url' for nil:NilClass if pull_request is nil
- use auto_merge function only when feature_package variable is set to docker

FIXES: 
https://builder.ci.pix4d.com/teams/main/pipelines/github-automation-master/jobs/docker-updater-pix4d-magma/builds/197