### PR TITLE
Change upstream branch to main

### DIFF
--- a/Dockerfile.pix4d
+++ b/Dockerfile.pix4d
@@ -12,12 +12,16 @@ COPY docker /home/dependabot/docker
 RUN apk update && \
   apk add --no-cache \
   g++ \
+  libxslt-dev \
+  libxml2-dev \
   make && \
   gem update --system && \
   gem install bundler --no-document
 
+
 WORKDIR /home/dependabot/docker/
 
+RUN bundle config build.nokogiri --use-system-libraries
 RUN bundle install
 
 FROM build AS tests

--- a/ci/pipelines/dependabot-template.yml
+++ b/ci/pipelines/dependabot-template.yml
@@ -46,9 +46,9 @@ resources:
     icon: git
     source:
       uri: https://github.com/dependabot/dependabot-core.git
-      branch: master
+      branch: main
       tag_filter: v*
-  
+
   - name: pix4d_build_tools.git
     type: git
     icon: git

--- a/ci/tasks/merge-upstream.py
+++ b/ci/tasks/merge-upstream.py
@@ -32,7 +32,7 @@ repo.config_writer().set_value("user", "name", COMMITER).release()
 
 git.Repo(os.curdir).create_remote("upstream", url="../upstream-dependabot-core.git")
 repo.git.checkout("-b", branch_name)
-repo.git.pull("upstream", "master")
+repo.git.pull("upstream", "main")
 
 changed_files = [item.a_path for item in repo.head.commit.diff('HEAD~1')]
 

--- a/ci/tasks/test-dependabot-task.yml
+++ b/ci/tasks/test-dependabot-task.yml
@@ -15,10 +15,15 @@ run:
       apk update && \
       apk add --no-cache \
         g++ \
+        libxslt-dev \
+        libxml2-dev \
         make && \
         gem update --system && \
         gem install bundler --no-document
+
+      bundle config build.nokogiri --use-system-libraries
+      bundle config set path '../../requirements'
       cd dependabot-core.git/docker
-      bundle install --path ../../requirements
+      bundle install
       bundle exec rspec ./spec/
       bundle exec rubocop ../


### PR DESCRIPTION
- no master branch exists upstream - changed to main
https://github.com/dependabot/dependabot-core

Master pipeline has a yellow resource, due to non-existing branch:
https://builder.ci.pix4d.com/teams/developers/pipelines/dependabot-master

- no new updates are automatically proposed until the fix.