### PR TITLE
PCI-1484 Auto merge the PR when no review is required

### DIFF
--- a/ci/pipelines/dependabot-template.yml
+++ b/ci/pipelines/dependabot-template.yml
@@ -36,10 +36,6 @@ resources:
       uri: git@github.com:Pix4D/dependabot-core.git
       private_key: ((concourse_janus_ssh_key))
       branch: ((branch))
-      paths:
-        - ci/*
-        - common/*
-        - docker/*
 
   - name: upstream-dependabot-core.git
     type: git
@@ -115,5 +111,7 @@ jobs:
     - get: known-hosts.s3
     - get: upstream-dependabot-core.git
       trigger: ((trigger))
+    - task: check-upstream-status
+      file: dependabot-core.git/ci/tasks/check-upstream-status-task.yml
     - task: merge-upstream
       file: dependabot-core.git/ci/tasks/merge-upstream-task.yml

--- a/ci/tasks/check-upstream-status-task.yml
+++ b/ci/tasks/check-upstream-status-task.yml
@@ -1,0 +1,24 @@
+platform: linux
+image_resource:
+  type: registry-image
+  source:
+    repository: python
+    tag: 3.8
+
+params:
+  REPOSITORY_ACCESS_TOKEN: ((dependabot_github_access_token))
+
+inputs:
+  - name: upstream-dependabot-core.git
+  - name: dependabot-core.git
+
+run:
+  path: bash
+  args:
+    - -c
+    - |
+      set -o errexit
+      pip install requests
+      cd dependabot-core.git
+      COMMIT=$(cat ../upstream-dependabot-core.git/.git/HEAD)
+      python ci/tasks/check-upstream-status.py --commit=$COMMIT --token=$REPOSITORY_ACCESS_TOKEN

--- a/ci/tasks/check-upstream-status.py
+++ b/ci/tasks/check-upstream-status.py
@@ -1,0 +1,66 @@
+""" For a commit that triggered the job, verify that all the checks successfully
+finished before trying to merge the upstream changes. Upstream checks can take up
+to 30 minutes, so we check multiple times (max 10), and wait 150 sec between the 
+attempts.
+"""
+
+import argparse
+import logging
+import sys
+import time
+
+import requests
+
+WAIT_TIME = 150
+
+logger = logging.getLogger("check-upstream-status")
+logging.basicConfig(level=logging.INFO)
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--commit", required=True, help="Upstream commit hash")
+# Github repository access token is used to avoid errors due to API rate limits
+parser.add_argument("--token", required=True, help="Github repository access token")
+args = parser.parse_args()
+
+num_check = 0
+max_checks = 10
+
+while num_check < max_checks:
+    num_check += 1
+    jobs = []
+    job_status = []
+    status_filter = []
+    data = requests.get(
+        f"https://api.github.com/repos/dependabot/dependabot-core/commits/{args.commit}/check-runs",
+        headers={"authorization":f"Bearer {args.token}", "Accept": "application/vnd.github.antiope-preview+json"},
+    )
+    if data.status_code != requests.codes.ok:
+        logger.error("HTTP request failed ")
+        logger.info(f"Waiting before checking upstream status again. This was attempt number: {num_check}")
+        time.sleep(WAIT_TIME)
+        continue
+
+    response = data.json()
+    job_status = [ (check_run["status"],check_run["conclusion"]) for check_run in response["check_runs"] ]
+    all_ok = all(item == ('completed', 'success') for item in job_status)
+    
+    if all_ok:
+        msg = f"Check the details here: https://github.com/dependabot/dependabot-core/commit/{args.commit}"
+        logger.info(msg)
+        logger.info("All " + str(response["total_count"]) + " checks finished successfully")
+        sys.exit(0)
+
+    logger.info(f"Waiting before checking upstream status again. This was attempt number: {num_check}")
+    time.sleep(WAIT_TIME)
+
+for check_run in response["check_runs"]:
+    if check_run["status"] != "completed" or check_run["conclusion"] != "success":
+        logger.error(f"Job name: {check_run['name']} status: {check_run['status']}, conclusion: {check_run['conclusion']}")
+
+msg = f"Check the details here: https://github.com/dependabot/dependabot-core/commit/{args.commit}" 
+logger.error("Some checks failed in the upstream repository")
+logger.error(msg)
+
+sys.exit(1)
+
+

--- a/ci/tasks/merge-upstream.py
+++ b/ci/tasks/merge-upstream.py
@@ -34,13 +34,13 @@ git.Repo(os.curdir).create_remote("upstream", url="../upstream-dependabot-core.g
 repo.git.checkout("-b", branch_name)
 repo.git.pull("upstream", "main")
 
-changed_files = [item.a_path for item in repo.head.commit.diff('HEAD~1')]
+changed_files = [item.a_path for item in repo.head.commit.diff("HEAD~1")]
 
 if not changed_files:
     print("No files were changed.")
     sys.exit(0)
 
-correct_files = any([filename.startswith('docker/') for filename in changed_files])
+correct_files = any([filename.startswith("docker/") for filename in changed_files])
 
 if correct_files:
     pr_title = "[changes-to-pix4d-dependabot] Merge the upstream changes"
@@ -52,6 +52,11 @@ repo.git.push("--set-upstream", "origin", branch_name)
 pr = (
     Github(access_token)
     .get_repo(MONITORED_REPO)
-    .create_pull(title=pr_title, base="master", head=branch_name, body=PR_MESSAGE,)
+    .create_pull(
+        title=pr_title,
+        base="master",
+        head=branch_name,
+        body=PR_MESSAGE,
+    )
 )
 print(pr.html_url)

--- a/ci/tasks/pr_auto_merge.rb
+++ b/ci/tasks/pr_auto_merge.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "octokit"
+
+github_token = ENV["GITHUB_ACCESS_TOKEN"]
+commit_hash = ENV["COMMIT_HASH"]
+project_path = "pix4d/dependabot-core"
+
+client = Octokit::Client.new(access_token: github_token)
+pr_list = client.pull_requests(project_path, state: "opened")
+
+pr_list.each do |pr|
+  unless (pr.head.sha == commit_hash) &&
+         pr.title.include?("[no-changes-to-pix4d-dependabot]")
+    next
+  end
+
+  commit_title = "Auto-merge pull request #{pr.number} from #{pr.head.ref}"
+  commit_msg = "Merge upstream changes to Pix4D fork"
+
+  client.merge_pull_request(
+    project_path,
+    pr.number,
+    commit_msg,
+    commit_title: commit_title
+  )
+
+  unless client.pull_merged?(project_path, pr.number)
+    raise "The PR was not merged correctly"
+  end
+
+  # Delete the branch if it exists. If it doesn't exist, swallow the exception.
+  begin
+    client.delete_branch(project_path, pr.head.ref)
+  rescue Octokit::UnprocessableEntity
+    nil
+  end
+end

--- a/ci/tasks/test-dependabot-task.yml
+++ b/ci/tasks/test-dependabot-task.yml
@@ -4,8 +4,12 @@ image_resource:
   source:
     repository: ruby
     tag: 2.7-alpine
+params:
+  REPOSITORY_ACCESS_TOKEN: ((dependabot_github_access_token))
+
 inputs:
 - name: dependabot-core.git
+
 run:
   path: /bin/sh
   args:
@@ -27,3 +31,5 @@ run:
       bundle install
       bundle exec rspec ./spec/
       bundle exec rubocop -c ../.rubocop.yml ../
+      export COMMIT_HASH=$(cat ../.git/ref)
+      bundle exec ruby ../ci/tasks/pr_auto_merge.rb

--- a/docker/README.PIX4D.md
+++ b/docker/README.PIX4D.md
@@ -62,21 +62,22 @@ contains two jobs:
 
 1. merge-upstream job is automatically triggered
     * fetches a new upstream version
+    * verify that all checks jobs finished successfully in the upstream repository
     * creates a feature branch in the forked repository
     * merges upstream changes
     * creates a PR in the forked repository
-       - PR title: [no-changes-to-pix4d-dependabot] - no review needed if tests are passing, otherwise reject the PR with explanation
+       - PR title: [no-changes-to-pix4d-dependabot] - no review needed. If tests are passing, this PR will be automerged in later steps
        - PR title: [changes-to-pix4d-dependabot] - more detailed review required. Review is necessary only for files in the `docker` folder. Suggestion: filter them in Github GUI
 
 2. The depenabot-core repository is monitored by set-pipeline job in Github-automation-tools pipeline - since the new PR is opened by the merge-upstream job,, PR resource detects it, sets a new featured pipeline, writes a comment in the PR with the pipeline URL and triggers the test-dependabot job
 
 3. Test-dependabot job runs unit tests that contain both upstream tests and our Pix4D modifications. Additionally it also runs rubocop a Ruby static code analyzer and code formatter
 
-4. If tests are green (passing test-dependabot is required) and PR gets 2 approvals, it can be merged to the master branch
+4. If tests are green (passing test-dependabot is required) and the PR title is [no-changes-to-pix4d-dependabot], the PR is automerged. Otherwise PR needs to get 2 approvals from PCI team members. Afterwhich, it can be merged to the master branch
 
 5. Any change in docker package manager folder or Pix4D Dockerfile, that is merged to master branch, triggers the build of new Docker image by linux-image-build-master pipeline
 
-Recently (August 2020), Github actions were activated in the upstream repository. This added 18 more checks to the repository. None of this checks are required for merging, but if they are not passing we should at least confirm that the checks are really failling upstream. We can verify this by checking lastest Actions workflows in the [upstream repository](https://github.com/dependabot/dependabot-core/actions) and finding the tag (18 CI jobs) that triggered the [Concourse job](https://builder.ci.pix4d.com/teams/developers/pipelines/dependabot-master/resources/upstream-dependabot-core.git). If we confirm that checks are failing upstream, we should probably wait for an upstream fix, especially if the cause for failing is related to rubocop. Otherwise, we should pull the feature branch from our forked repo and try to fix it.  
+Recently (August 2020), Github actions were activated in the upstream repository. The Github actions are disabled for Pix4D forked repository, so we added a step in the merge-upstream pipeline job to verify all the checks are passing upstream. If any of the checks fail upstream we do not merge the upstream changes into Pix4D forked repository.
 
 _CASE:_ upstream changes are merged in the feature branch, PR is opened, but the tests (rspec for `docker` package manager or rubocop) fail. What should I do?
 


### PR DESCRIPTION
- first commit:  only a boyscout:  Use black on existing Python scripts
- second commit: 
    * (merge-upstream job) includes the scripts/tasks to verify that all checks are green in the upstream commit/tag before trying to merge upstream changes to a feature branch. No PR is opened if this job fails, but we are notified on Gchat channel about failing job.
If all is fine and the job finish with success, a PR is opened, in the same way as it is now, with two possible PR titles. Github-automation-tools (PR resource in pipeline setter) monitors this repository and detects a new PR is opened, it creates a featured pipeline and triggers the test-dependabot job. 
    * This job runs all rspec tests and rubocop, after which, if all is green, checks if the PR title and SHA are correct and automerged it if needed. 

Also, I have disabled Github Actions for this repo.
 
- [x] Update README.PIX4D.md