### PR TITLE
PCI-1484 Increase wait time in check upstream task

### DIFF
--- a/ci/pipelines/dependabot-template.yml
+++ b/ci/pipelines/dependabot-template.yml
@@ -94,7 +94,7 @@ jobs:
       file: dependabot-core.git/ci/tasks/test-dependabot-task.yml
 
   - name: merge-upstream
-    disable_manual_trigger: true
+    disable_manual_trigger: ((disable_on_feature))
     on_error:
       do:
       - put: google-chat

--- a/ci/settings/feature-branch.yml
+++ b/ci/settings/feature-branch.yml
@@ -3,3 +3,4 @@ gchat_hook:
 trigger: false
 pr_bot_triggered_jobs:
     - test-dependabot
+disable_on_feature: true

--- a/ci/settings/master-branch.yml
+++ b/ci/settings/master-branch.yml
@@ -2,3 +2,4 @@ project: dependabot
 branch: master
 gchat_hook: ((gchat_hook_integration_team))
 trigger: true
+disable_on_feature: false

--- a/ci/tasks/check-upstream-status.py
+++ b/ci/tasks/check-upstream-status.py
@@ -1,6 +1,6 @@
 """ For a commit that triggered the job, verify that all the checks successfully
 finished before trying to merge the upstream changes. Upstream checks can take up
-to 30 minutes, so we check multiple times (max 10), and wait 150 sec between the 
+to 30 minutes, so we check multiple times (max 12), and wait 300 sec between the 
 attempts.
 """
 
@@ -11,7 +11,7 @@ import time
 
 import requests
 
-WAIT_TIME = 150
+WAIT_TIME = 300
 
 logger = logging.getLogger("check-upstream-status")
 logging.basicConfig(level=logging.INFO)
@@ -23,7 +23,7 @@ parser.add_argument("--token", required=True, help="Github repository access tok
 args = parser.parse_args()
 
 num_check = 0
-max_checks = 10
+max_checks = 12
 
 while num_check < max_checks:
     num_check += 1


### PR DESCRIPTION
- the longest job upstream can take almost 40 minutes, increase of the wait time is hence required
- disable job manual trigger only on feature branch

Failing jobs:
https://builder.ci.pix4d.com/teams/developers/pipelines/dependabot-master/jobs/merge-upstream/builds/34
https://builder.ci.pix4d.com/teams/developers/pipelines/dependabot-master/jobs/merge-upstream/builds/35
In both cases due to the same job upstream not finished in time:
`ERROR:check-upstream-status:Job name: CI (python) status: in_progress, conclusion: None`

To verify:
https://github.com/dependabot/dependabot-core/runs/1144453172
The upstream job took 38m to finish. We were waiting 25 minutes.