### PR TITLE
PCI-1724 Add integration tests

### DIFF
--- a/docker/dependabot-main.rb
+++ b/docker/dependabot-main.rb
@@ -1,22 +1,13 @@
 # frozen_string_literal: true
 
-# LIST OF ENVIROMENTAL VARIABLES NEEDED:
-# FEATURE_PACKAGE i.e docker or concourse
-# PROJECT_PATH i.e. Pix4D/test-dependabot-docker
-# DEPENDENCY_DIRECTORY i.e. ci/docker or ci/pipelines
-# REPOSITORY_BRANCH default is master
-# GITHUB_ACCESS_TOKEN
-# DOCKER_REGISTRY i.e. docker.ci.pix4d.com
-# DOCKER_USER
-# DOCKER_PASS
-
 require "dependabot/docker"
 require "dependabot/auto_merge"
 require "dependabot/pr_info"
 require "dependabot/path_level"
 
 def pr_creator(source, commit, updated_deps, updated_files, credentials_github)
-  Dependabot::PullRequestCreator.new(
+  # Create a pull request for the update
+  pr = Dependabot::PullRequestCreator.new(
     source: source,
     base_commit: commit,
     dependencies: updated_deps,
@@ -27,6 +18,7 @@ def pr_creator(source, commit, updated_deps, updated_files, credentials_github)
     branch_name_separator: "-",
     pr_message_footer: pr_info(updated_deps.first)
   )
+  pr.create
 end
 
 def requirements(checker)
@@ -42,89 +34,128 @@ def requirements(checker)
   requirements
 end
 
-credentials_github =
-  [{
-    "type" => "git_source",
-    "host" => "github.com",
-    "username" => "dependabot-script",
-    "password" => ENV["GITHUB_ACCESS_TOKEN"]
-  }]
-
-credentials_docker =
-  [{
-    "type" => "docker_registry",
-    "registry" => (ENV["DOCKER_REGISTRY"] || "registry.hub.docker.com"),
-    "username" => (ENV["DOCKER_USER"] || nil),
-    "password" => (ENV["DOCKER_PASS"] || nil)
-  }]
-
-input_files_path = recursive_path(
-  ENV["FEATURE_PACKAGE"],
-  ENV["PROJECT_PATH"],
-  ENV["DEPENDENCY_DIRECTORY"],
-  ENV["GITHUB_ACCESS_TOKEN"]
-)
-
-# rubocop:disable Metrics/BlockLength
-input_files_path.each do |file_path|
-  # Source setup
-  print "  - Checking the file in #{file_path}\n"
-  source = Dependabot::Source.new(
-    provider: "github", repo: ENV["PROJECT_PATH"],
-    directory: file_path, branch: (ENV["REPOSITORY_BRANCH"] || nil)
-  )
+def file_fetcher(source, credentials_github)
   # Fetch the dependency files
   fetcher = Dependabot::FileFetchers.for_package_manager("docker").
             new(source: source, credentials: credentials_github)
 
   files = fetcher.files
   commit = fetcher.commit
+
+  [files, commit]
+end
+
+def file_parser(files, source)
   # Parse the dependency files
   parser = Dependabot::FileParsers.for_package_manager("docker").new(
     dependency_files: files, source: source
   )
-  dependencies = parser.parse
-
-  dependencies.select(&:top_level?).each do |dep|
-    # Get update details for the dependency
-    checker = Dependabot::UpdateCheckers.for_package_manager("docker").new(
-      dependency: dep, dependency_files: files, credentials: credentials_docker
-    )
-    next if checker.up_to_date?
-
-    requirements_to_unlock = requirements(checker)
-    next if requirements_to_unlock == :update_not_possible
-
-    updated_deps = checker.updated_dependencies(
-      requirements_to_unlock: requirements_to_unlock
-    )
-
-    next if updated_deps.first.version == updated_deps.first.previous_version
-
-    # Generate updated dependency files
-    print "  - Updating #{dep.name} (from #{dep.version}) \n"
-    updater = Dependabot::FileUpdaters.for_package_manager("docker").new(
-      dependencies: updated_deps, dependency_files: files, credentials: nil
-    )
-    updated_files = updater.updated_dependency_files
-
-    # Create a pull request for the update
-    pr = pr_creator(source, commit, updated_deps,
-                    updated_files, credentials_github)
-
-    pull_request = pr.create
-
-    next unless pull_request
-
-    puts pull_request.html_url
-
-    next unless ENV["FEATURE_PACKAGE"] == "docker"
-
-    auto_merge(pull_request.number,
-               pull_request.head.ref,
-               ENV["PROJECT_PATH"],
-               ENV["GITHUB_ACCESS_TOKEN"])
-  end
+  parser.parse
 end
-puts "Done"
-# rubocop:enable Metrics/BlockLength
+
+def file_updater(dep, updated_deps, files)
+  # Generate updated dependency files
+  print "  - Updating #{dep.name} (from #{dep.version}) \n"
+  updater = Dependabot::FileUpdaters.for_package_manager("docker").new(
+    dependencies: updated_deps, dependency_files: files, credentials: nil
+  )
+  updater.updated_dependency_files
+end
+
+def checker_init(dep, files, docker_cred)
+  # Get update details for the dependency
+  Dependabot::UpdateCheckers.for_package_manager("docker").new(
+    dependency: dep, dependency_files: files, credentials: [docker_cred]
+  )
+end
+
+def source_init(file_path, project_data)
+  Dependabot::Source.new(
+    provider: "github", repo: project_data["repo"],
+    directory: file_path, branch: project_data["branch"]
+  )
+end
+
+def checker_up_to_date(checker)
+  checker.up_to_date?
+end
+
+def checker_updated_dependencies(checker, requirements_to_unlock)
+  checker.updated_dependencies(
+    requirements_to_unlock: requirements_to_unlock
+  )
+end
+
+def main(project_data, github_token, docker_cred)
+  credentials_github = [{
+    "type" => "git_source",
+    "host" => "github.com",
+    "username" => "dependabot-script",
+    "password" => github_token
+  }]
+
+  input_files_path = recursive_path(
+    project_data["module"],
+    project_data["repo"],
+    project_data["dependency_dir"],
+    github_token
+  )
+
+  input_files_path.each do |file_path|
+    print "  - Checking the files in #{file_path}\n"
+    source = source_init(file_path, project_data)
+    files, commit = file_fetcher(source, credentials_github)
+    dependencies = file_parser(files, source)
+
+    dependencies.select(&:top_level?).each do |dep|
+      checker = checker_init(dep, files, docker_cred)
+      next if checker_up_to_date(checker)
+
+      requirements_to_unlock = requirements(checker)
+      next if requirements_to_unlock == :update_not_possible
+
+      updated_deps = checker_updated_dependencies(checker, requirements_to_unlock)
+      next if updated_deps.first.version == updated_deps.first.previous_version
+
+      updated_files = file_updater(dep, updated_deps, files)
+      pull_request = pr_creator(source, commit, updated_deps, updated_files, credentials_github)
+      next unless pull_request
+
+      puts pull_request[:html_url]
+      next unless project_data["module"] == "docker"
+
+      auto_merge(pull_request[:number], pull_request[:head][:ref], project_data["repo"], github_token)
+    end
+  end
+  "Success"
+end
+
+# LIST OF ENVIROMENTAL VARIABLES NEEDED:
+# FEATURE_PACKAGE i.e docker or concourse
+# PROJECT_PATH i.e. Pix4D/test-dependabot-docker
+# DEPENDENCY_DIRECTORY i.e. ci/docker or ci/pipelines
+# REPOSITORY_BRANCH default is master
+# GITHUB_ACCESS_TOKEN
+# DOCKER_REGISTRY i.e. docker.ci.pix4d.com
+# DOCKER_USER
+# DOCKER_PASS
+
+# PROGRAM ENTRY POINT
+if __FILE__ == $PROGRAM_NAME
+  docker_cred = {
+    "type" => "docker_registry",
+    "registry" => (ENV["DOCKER_REGISTRY"] || "registry.hub.docker.com"),
+    "username" => (ENV["DOCKER_USER"] || nil),
+    "password" => (ENV["DOCKER_PASS"] || nil)
+  }
+  # this is current behaviour, that we will change in the next PR to allow for project_data from multiple repositories
+  project_data = {
+    "module" => ENV["FEATURE_PACKAGE"],
+    "repo" => ENV["PROJECT_PATH"],
+    "branch" => ENV["REPOSITORY_BRANCH"],
+    "dependency_dir" => ENV["DEPENDENCY_DIRECTORY"]
+  }
+  github_token = ENV["GITHUB_ACCESS_TOKEN"]
+
+  main(project_data, github_token, docker_cred)
+end

--- a/docker/dependabot-main.rb
+++ b/docker/dependabot-main.rb
@@ -94,12 +94,7 @@ def main(project_data, github_token, docker_cred)
     "password" => github_token
   }]
 
-  input_files_path = recursive_path(
-    project_data["module"],
-    project_data["repo"],
-    project_data["dependency_dir"],
-    github_token
-  )
+  input_files_path = recursive_path(project_data, github_token)
 
   input_files_path.each do |file_path|
     print "  - Checking the files in #{file_path}\n"

--- a/docker/dependabot-main_spec.rb
+++ b/docker/dependabot-main_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require_relative "dependabot-main"
+
+# rubocop:disable Metrics/BlockLength
+RSpec.describe "main function", :pix4d do
+  def fixture(*name)
+    File.read(File.join("spec", "fixtures", *name))
+  end
+
+  let(:fake_token) { "github_token" }
+  let(:docker_cred) do
+    {
+      "type" => "docker_registry",
+      "registry" => "registry.hub.docker.com",
+      "username" => nil,
+      "password" => nil
+    }
+  end
+
+  let(:dependency_instance) do
+    Dependabot::Dependency.new(
+      name: dependency_name,
+      version: version,
+      requirements: [{
+        requirement: nil,
+        groups: [],
+        file: file_name,
+        source: { tag: version }
+      }],
+      package_manager: "docker"
+    )
+  end
+  let(:updated_dependency_instance) do
+    Dependabot::Dependency.new(
+      name: dependency_name,
+      version: updated_version,
+      previous_version: version,
+      requirements: [{
+        requirement: nil,
+        groups: [],
+        file: file_name,
+        source: { tag: updated_version }
+      }],
+      previous_requirements: [{
+        requirement: nil,
+        groups: [],
+        file: file_name,
+        source: { tag: version }
+      }],
+      package_manager: "docker"
+    )
+  end
+  let(:dependency_file) do
+    Dependabot::DependencyFile.new(name: file_name, content: fixture_file, directory: dependency_dir)
+  end
+
+  let(:expected_commit) { "c1a68d7" }
+  let(:file_name) { "public-simple.yml" }
+  let(:dependency_name) { "public-image-name-1" }
+  let(:version) { "1.0.7" }
+  let(:updated_version) { "1.10" }
+  let(:pull_request) do
+    {
+      number: 1,
+      head: { ref: "docker-#{dependency_dir[0..-2].sub('/', '-')}-#{branch}-#{dependency_name}-#{version}" },
+      html_url: "https://github.com/#{repo}/pull/1"
+    }
+  end
+
+  context "happy path for concourse module" do
+    let(:project_data) do
+      {
+        "module" => "concourse",
+        "repo" => "Pix4D/test_repo",
+        "branch" => "master",
+        "dependency_dir" => "ci/pipelines/"
+      }
+    end
+
+    let(:fixture_file) { fixture("pipelines", file_name) }
+    let(:dependency_dir) { project_data["dependency_dir"] }
+    let(:repo) { project_data["repo"] }
+    let(:branch) { project_data["branch"] }
+
+    it "returns the correct project_path" do
+      allow(self).to receive(:recursive_path).and_return([dependency_dir])
+      allow(self).to receive(:file_fetcher).and_return([[dependency_file], expected_commit])
+      allow(self).to receive(:file_parser).and_return([dependency_instance])
+      allow(self).to receive(:checker_up_to_date).and_return(false)
+      allow(self).to receive(:requirements).and_return(":own")
+      allow(self).to receive(:checker_updated_dependencies).and_return([updated_dependency_instance])
+      allow(self).to receive(:pr_creator).and_return(pull_request)
+
+      actual = main(project_data, fake_token, docker_cred)
+      expect(actual).to equal("Success")
+    end
+  end
+end
+# rubocop:enable Metrics/BlockLength

--- a/docker/dependabot-main_spec.rb
+++ b/docker/dependabot-main_spec.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
 require_relative "dependabot-main"
+require "spec_helper"
 
 # rubocop:disable Metrics/BlockLength
-RSpec.describe "main function", :pix4d do
+RSpec.describe "describe main function", :pix4d do
   def fixture(*name)
     File.read(File.join("spec", "fixtures", *name))
   end
@@ -54,6 +55,7 @@ RSpec.describe "main function", :pix4d do
   let(:dependency_file) do
     Dependabot::DependencyFile.new(name: file_name, content: fixture_file, directory: dependency_dir)
   end
+  let(:github_url) { "https://api.github.com/" }
 
   let(:expected_commit) { "c1a68d7" }
   let(:file_name) { "public-simple.yml" }
@@ -91,6 +93,60 @@ RSpec.describe "main function", :pix4d do
       allow(self).to receive(:requirements).and_return(":own")
       allow(self).to receive(:checker_updated_dependencies).and_return([updated_dependency_instance])
       allow(self).to receive(:pr_creator).and_return(pull_request)
+
+      actual = main(project_data, fake_token, docker_cred)
+      expect(actual).to equal("Success")
+    end
+  end
+
+  context "for docker module" do
+    let(:project_data) do
+      {
+        "module" => "docker",
+        "repo" => "Pix4D/test_repo",
+        "branch" => "staging",
+        "dependency_dir" => "dockerfiles/"
+      }
+    end
+
+    let(:github_sha) { "76abc" }
+    let(:repo) { project_data["repo"] }
+    let(:branch) { project_data["branch"] }
+    let(:url1) { github_url + "repos/#{repo}/branches/#{branch}" }
+    let(:url2) do
+      github_url +
+        "repos/#{repo}/git/trees/#{github_sha}?recursive=true"
+    end
+    let(:fixture_file) { fixture("pipelines", file_name) }
+    let(:dependency_dir) { project_data["dependency_dir"] }
+    let(:repo) { project_data["repo"] }
+    let(:branch) { project_data["branch"] }
+    before do
+      stub_request(:get, url1).
+        to_return(
+          status: 200,
+          body: { "name": branch, "commit": { "sha": github_sha } }.to_json,
+          headers: { "content-type" => "application/json" }
+        )
+      stub_request(:get, url2).
+        to_return(
+          status: 200,
+          body: { "sha": github_sha, "tree": [
+            { "path": "dockerfiles/folder-1/Dockerfile" }
+          ] }.to_json,
+          headers: { "content-type" => "application/json" }
+        )
+    end
+
+    it "when directory tree for staging branch is wanted" do
+
+      allow(self).to receive(:file_fetcher).and_return([[dependency_file], expected_commit])
+      allow(self).to receive(:file_parser).and_return([dependency_instance])
+      allow(self).to receive(:checker_up_to_date).and_return(false)
+      allow(self).to receive(:requirements).and_return(":own")
+      allow(self).to receive(:checker_updated_dependencies).and_return([updated_dependency_instance])
+      allow(self).to receive(:pr_creator).and_return(pull_request)
+      allow(self).to receive(:auto_merge).and_return("")
 
       actual = main(project_data, fake_token, docker_cred)
       expect(actual).to equal("Success")

--- a/docker/dependabot-main_spec.rb
+++ b/docker/dependabot-main_spec.rb
@@ -87,12 +87,12 @@ RSpec.describe "describe main function", :pix4d do
 
     it "returns the correct project_path" do
       allow(self).to receive(:recursive_path).and_return([dependency_dir])
-      allow(self).to receive(:file_fetcher).and_return([[dependency_file], expected_commit])
-      allow(self).to receive(:file_parser).and_return([dependency_instance])
+      allow(self).to receive(:fetch_files_and_commit).and_return([[dependency_file], expected_commit])
+      allow(self).to receive(:fetch_dependencies).and_return([dependency_instance])
       allow(self).to receive(:checker_up_to_date).and_return(false)
       allow(self).to receive(:requirements).and_return(":own")
       allow(self).to receive(:checker_updated_dependencies).and_return([updated_dependency_instance])
-      allow(self).to receive(:pr_creator).and_return(pull_request)
+      allow(self).to receive(:create_pr).and_return(pull_request)
 
       actual = main(project_data, fake_token, docker_cred)
       expect(actual).to equal("Success")
@@ -139,12 +139,12 @@ RSpec.describe "describe main function", :pix4d do
     end
 
     it "when directory tree for staging branch is wanted" do
-      allow(self).to receive(:file_fetcher).and_return([[dependency_file], expected_commit])
-      allow(self).to receive(:file_parser).and_return([dependency_instance])
+      allow(self).to receive(:fetch_files_and_commit).and_return([[dependency_file], expected_commit])
+      allow(self).to receive(:fetch_dependencies).and_return([dependency_instance])
       allow(self).to receive(:checker_up_to_date).and_return(false)
       allow(self).to receive(:requirements).and_return(":own")
       allow(self).to receive(:checker_updated_dependencies).and_return([updated_dependency_instance])
-      allow(self).to receive(:pr_creator).and_return(pull_request)
+      allow(self).to receive(:create_pr).and_return(pull_request)
       allow(self).to receive(:auto_merge).and_return("")
 
       actual = main(project_data, fake_token, docker_cred)

--- a/docker/dependabot-main_spec.rb
+++ b/docker/dependabot-main_spec.rb
@@ -139,7 +139,6 @@ RSpec.describe "describe main function", :pix4d do
     end
 
     it "when directory tree for staging branch is wanted" do
-
       allow(self).to receive(:file_fetcher).and_return([[dependency_file], expected_commit])
       allow(self).to receive(:file_parser).and_return([dependency_instance])
       allow(self).to receive(:checker_up_to_date).and_return(false)

--- a/docker/lib/dependabot/path_level.rb
+++ b/docker/lib/dependabot/path_level.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
-def recursive_path(feature_package, project_path, dependency_dir, github_token)
-  if feature_package == "docker"
+def recursive_path(project_data, github_token)
+  if project_data["module"] == "docker"
 
     client = Octokit::Client.new(access_token: github_token)
-    branch = client.branch(project_path, "master")
-    tree = client.tree(project_path, branch.commit.sha, recursive: true).tree
+    branch = client.branch(project_data["repo"], project_data["branch"])
+    tree = client.tree(project_data["repo"], branch.commit.sha, recursive: true).tree
 
-    selected_paths = tree.select { |f| f.path.include?(dependency_dir.to_s) }.
+    selected_paths = tree.select { |f| f.path.include?(project_data["dependency_dir"].to_s) }.
                      select { |f| f.path.include?("Dockerfile") }.
                      map(&:path)
 
@@ -17,6 +17,6 @@ def recursive_path(feature_package, project_path, dependency_dir, github_token)
       input_files_path << path
     end
   else
-    input_files_path = [dependency_dir]
+    input_files_path = [project_data["dependency_dir"]]
   end
 end


### PR DESCRIPTION
This PR contains only:
- (first commit) refactoring of dependabot main script without any behavior changes
- (first commit) add integration tests for the main script
- (second commit) add regression test (failing because main code tries to fetch wrong branch)
- (third commit) pass the regression test
