### PR TITLE
PCI-1724 [dependabot] Print working path/repository

### DIFF
--- a/docker/dependabot-main.rb
+++ b/docker/dependabot-main.rb
@@ -97,6 +97,7 @@ def main(project_data, github_token, docker_cred)
 
   input_files_path = recursive_path(project_data, github_token)
 
+  print "Working in #{project_data['repo']}\n"
   input_files_path.each do |file_path|
     print "  - Checking the files in #{file_path}\n"
     source = source_init(file_path, project_data)
@@ -117,7 +118,8 @@ def main(project_data, github_token, docker_cred)
       pull_request = create_pr(source, commit, updated_deps, updated_files, credentials_github)
       next unless pull_request
 
-      puts pull_request[:html_url]
+      print "#{pull_request[:html_url]}\n\n"
+
       next unless project_data["module"] == "docker"
 
       auto_merge(pull_request[:number], pull_request[:head][:ref], project_data["repo"], github_token)


### PR DESCRIPTION
Current message are missing the working path/repository:
https://builder.ci.pix4d.com/teams/main/pipelines/github-automation-master/jobs/docker-updater/builds/1#L60162c2e:11
```
  - Checking the files in ci/pipelines/
  - Updating cpp-builder-ubuntu-18.04 (from 20200727101136) 
  - Updating cpp-tester-ubuntu-18.04 (from 20200727101507) 
```
Above is not very useful without printing in which repository Depedabot is currently working.

This PR improves the messages to following form:
```
Working in Pix4D/test_repo
  - Checking the files in dockerfiles/folder-1
    - Updating public-image-name-1 (from 1.0.7) 
https://github.com/Pix4D/test_repo/pull/1
Working in Pix4D/test_repo
  - Checking the files in ci/pipelines/
    - Updating public-image-name-1 (from 1.0.7) 
https://github.com/Pix4D/test_repo/pull/1
```