### PR TITLE
PCI-1595 Allow for multiple dependencies in a single PR

### DIFF
--- a/pix4d-dependabot/lib/helpers/helper_dependabot.rb
+++ b/pix4d-dependabot/lib/helpers/helper_dependabot.rb
@@ -14,7 +14,7 @@ def create_pr(package_manager, source, commit, updated_deps, updated_files, cred
   pr = Dependabot::PullRequestCreator.new(
     source: source,
     base_commit: commit,
-    dependencies: updated_deps.first,
+    dependencies: updated_deps,
     files: updated_files,
     credentials: credentials_github,
     label_language: true,
@@ -120,7 +120,7 @@ def pix4_dependabot(package_manager, project_data, github_credentials, extra_cre
 
     next if updated_deps.empty?
 
-    pull_request = create_pr(package_manager, source, commit, updated_deps, files,
+    pull_request = create_pr(package_manager, source, commit, updated_deps.flatten(1), files,
                              [github_credentials])
     next unless pull_request
 

--- a/pix4d-dependabot/lib/helpers/helper_dependabot.rb
+++ b/pix4d-dependabot/lib/helpers/helper_dependabot.rb
@@ -91,36 +91,38 @@ def checker_updated_dependencies(checker, requirements_to_unlock)
   )
 end
 
-# rubocop:disable Metrics/AbcSize
-# rubocop:disable Metrics/PerceivedComplexity
+def dependencies_updater(package_manager, files, dependencies, github_credentials, extra_credentials)
+  updated_deps = []
+  dependencies.select(&:top_level?).each do |dep|
+    checker = checker_init(package_manager, dep, files, extra_credentials)
+    next if checker_up_to_date(checker)
+
+    requirements_to_unlock = requirements(checker)
+    next if requirements_to_unlock == :update_not_possible
+
+    updated_dep = checker_updated_dependencies(checker, requirements_to_unlock)
+    next if updated_dep.first.version == updated_dep.first.previous_version
+
+    files = update_files(package_manager, dep, updated_dep, files, [github_credentials])
+    updated_deps << updated_dep
+  end
+  [files, updated_deps.flatten(1)]
+end
+
 def pix4_dependabot(package_manager, project_data, github_credentials, extra_credentials)
   input_files_path = recursive_path(project_data, github_credentials["password"])
 
   print "Working in #{project_data['repo']}\n"
   input_files_path.each do |file_path|
-    updated_deps = []
     print "  - Checking the files in #{file_path}\n"
     source = source_init(file_path, project_data)
     files, commit = fetch_files_and_commit(package_manager, source, [github_credentials])
     dependencies = fetch_dependencies(package_manager, files, source)
-
-    dependencies.select(&:top_level?).each do |dep|
-      checker = checker_init(package_manager, dep, files, extra_credentials)
-      next if checker_up_to_date(checker)
-
-      requirements_to_unlock = requirements(checker)
-      next if requirements_to_unlock == :update_not_possible
-
-      updated_dep = checker_updated_dependencies(checker, requirements_to_unlock)
-      next if updated_dep.first.version == updated_dep.first.previous_version
-
-      files = update_files(package_manager, dep, updated_dep, files, [github_credentials])
-      updated_deps << updated_dep
-    end
-
+    updated_files, updated_deps = dependencies_updater(package_manager, files, dependencies, github_credentials,
+                                                       extra_credentials)
     next if updated_deps.empty?
 
-    pull_request = create_pr(package_manager, source, commit, updated_deps.flatten(1), files,
+    pull_request = create_pr(package_manager, source, commit, updated_deps, updated_files,
                              [github_credentials])
     next unless pull_request
 
@@ -132,5 +134,3 @@ def pix4_dependabot(package_manager, project_data, github_credentials, extra_cre
   end
   "Success"
 end
-# rubocop:enable Metrics/AbcSize
-# rubocop:enable Metrics/PerceivedComplexity

--- a/pix4d-dependabot/spec/helpers/helper_dependabot_spec.rb
+++ b/pix4d-dependabot/spec/helpers/helper_dependabot_spec.rb
@@ -3,12 +3,22 @@
 require "helpers/helper_dependabot"
 require_relative "spec_helper"
 
-RSpec.describe "describe pix4_dependabot function", :pix4d do
-  def fixture(*name)
-    File.read(File.join("..", "docker", "spec", "fixtures", *name))
-  end
+def fixture(package_manager, *name)
+  File.read(File.join("..", package_manager, "spec", "fixtures", *name))
+end
 
+RSpec.describe "describe pix4_dependabot function", :pix4d do
+  let(:github_url) { "https://api.github.com/" }
   let(:fake_token) { "github_token" }
+  let(:expected_commit) { "c1a68d7" }
+  let(:git_cred) do
+    {
+      "type" => "git_source",
+      "host" => "github.com",
+      "username" => "dependabot-script",
+      "password" => fake_token
+    }
+  end
   let(:docker_cred) do
     {
       "type" => "docker_registry",
@@ -17,193 +27,147 @@ RSpec.describe "describe pix4_dependabot function", :pix4d do
       "password" => nil
     }
   end
-
-  let(:dependency_instance) do
-    Dependabot::Dependency.new(
-      name: dependency_name,
-      version: version,
-      requirements: [{
-        requirement: nil,
-        groups: [],
-        file: file_name,
-        source: { tag: version }
-      }],
-      package_manager: "docker"
-    )
-  end
-  let(:updated_dependency_instance) do
-    Dependabot::Dependency.new(
-      name: dependency_name,
-      version: updated_version,
-      previous_version: version,
-      requirements: [{
-        requirement: nil,
-        groups: [],
-        file: file_name,
-        source: { tag: updated_version }
-      }],
-      previous_requirements: [{
-        requirement: nil,
-        groups: [],
-        file: file_name,
-        source: { tag: version }
-      }],
-      package_manager: "docker"
-    )
+  let(:artifactory_cred) do
+    {
+      "EXTRA_INDEX_URL" => "https://artifactory.test.ci.pix4d.com/artifactory/api/pypi/pix4d-pypi-local/simple",
+      "username" => nil,
+      "password" => nil
+    }
   end
   let(:dependency_file) do
     Dependabot::DependencyFile.new(name: file_name, content: fixture_file, directory: dependency_dir)
   end
-  let(:github_url) { "https://api.github.com/" }
+  let(:dependency_dir) { project_data["dependency_dir"] }
+  let(:repo) { project_data["repo"] }
+  let(:branch) { project_data["branch"] }
 
-  let(:expected_commit) { "c1a68d7" }
-  let(:file_name) { "public-simple.yml" }
-  let(:dependency_name) { "public-image-name-1" }
-  let(:version) { "1.0.7" }
-  let(:updated_version) { "1.10" }
-  let(:pull_request) do
-    {
-      number: 1,
-      head: { ref: "docker-#{dependency_dir[0..-2].sub('/', '-')}-#{branch}-#{dependency_name}-#{version}" },
-      html_url: "https://github.com/#{repo}/pull/1"
-    }
-  end
-
-  context "happy path for concourse module" do
-    let(:project_data) do
-      {
-        "module" => "concourse",
-        "repo" => "Pix4D/test_repo",
-        "branch" => "master",
-        "dependency_dir" => "ci/pipelines/"
-      }
-    end
-    let(:docker_cred) do
-      {
-        "type" => "docker_registry",
-        "registry" => "registry.hub.docker.com",
-        "username" => nil,
-        "password" => nil
-      }
-    end
-    let(:git_cred) do
-      {
-        "type" => "git_source",
-        "host" => "github.com",
-        "username" => "dependabot-script",
-        "password" => fake_token
-      }
-    end
-    let(:fixture_file) { fixture("pipelines", file_name) }
-    let(:dependency_dir) { project_data["dependency_dir"] }
-    let(:repo) { project_data["repo"] }
-    let(:branch) { project_data["branch"] }
-
-    it "returns the correct project_path" do
-      allow(self).to receive(:recursive_path).and_return([dependency_dir])
-      allow(self).to receive(:fetch_files_and_commit).and_return([[dependency_file], expected_commit])
-      allow(self).to receive(:fetch_dependencies).and_return([dependency_instance])
-      allow(self).to receive(:checker_up_to_date).and_return(false)
-      allow(self).to receive(:requirements).and_return(":own")
-      allow(self).to receive(:checker_updated_dependencies).and_return([updated_dependency_instance])
-      allow(self).to receive(:create_pr).and_return(pull_request)
-
-      actual = pix4_dependabot("docker", project_data, git_cred, docker_cred)
-      expect(actual).to equal("Success")
-    end
-  end
-
-  context "for docker module" do
-    let(:project_data) do
-      {
-        "module" => "docker",
-        "repo" => "Pix4D/test_repo",
-        "branch" => "staging",
-        "dependency_dir" => "dockerfiles/"
-      }
-    end
-
-    let(:github_sha) { "76abc" }
-    let(:repo) { project_data["repo"] }
-    let(:branch) { project_data["branch"] }
-    let(:url1) { github_url + "repos/#{repo}/branches/#{branch}" }
-    let(:url2) do
-      github_url +
-        "repos/#{repo}/git/trees/#{github_sha}?recursive=true"
-    end
-    let(:fixture_file) { fixture("pipelines", file_name) }
-    let(:dependency_dir) { project_data["dependency_dir"] }
-    let(:repo) { project_data["repo"] }
-    let(:branch) { project_data["branch"] }
-    before do
-      stub_request(:get, url1).
-        to_return(
-          status: 200,
-          body: { "name": branch, "commit": { "sha": github_sha } }.to_json,
-          headers: { "content-type" => "application/json" }
-        )
-      stub_request(:get, url2).
-        to_return(
-          status: 200,
-          body: { "sha": github_sha, "tree": [
-            { "path": "dockerfiles/folder-1/Dockerfile" }
-          ] }.to_json,
-          headers: { "content-type" => "application/json" }
-        )
-    end
-
-    it "when directory tree for staging branch is wanted" do
-      allow(self).to receive(:fetch_files_and_commit).and_return([[dependency_file], expected_commit])
-      allow(self).to receive(:fetch_dependencies).and_return([dependency_instance])
-      allow(self).to receive(:checker_up_to_date).and_return(false)
-      allow(self).to receive(:requirements).and_return(":own")
-      allow(self).to receive(:checker_updated_dependencies).and_return([updated_dependency_instance])
-      allow(self).to receive(:create_pr).and_return(pull_request)
-      allow(self).to receive(:auto_merge).and_return("")
-
-      actual = pix4_dependabot("docker", project_data, fake_token, docker_cred)
-      expect(actual).to equal("Success")
-    end
-  end
-
-  context "happy path for python module" do
-    let(:project_data) do
-      {
-        "module" => "pip",
-        "repo" => "Pix4D/test_repo",
-        "branch" => "master",
-        "dependency_dir" => "/"
-      }
-    end
-    let(:artifactory_cred) do
-      {
-        "EXTRA_INDEX_URL" => "https://artifactory.test.ci.pix4d.com/artifactory/api/pypi/pix4d-pypi-local/simple",
-        "username" => nil,
-        "password" => nil
-      }
-    end
-    let(:git_cred) do
-      {
-        "type" => "git_source",
-        "host" => "github.com",
-        "username" => "dependabot-script",
-        "password" => fake_token
-      }
-    end
-    let(:file_name) { "base_requirements.txt" }
-    let(:fixture_file) do
-      File.read(File.join("..", "python", "spec", "fixtures", "requirements", "base_requirements.txt"))
-    end
-    let(:dependency_dir) { project_data["dependency_dir"] }
-    let(:repo) { project_data["repo"] }
-    let(:branch) { project_data["branch"] }
-    let(:dependency_name) { "requests" }
+  describe "using Docker package manager" do
     let(:dependency_instance) do
       Dependabot::Dependency.new(
         name: dependency_name,
-        version: "2.18.4",
+        version: version,
         requirements: [{
-          requirement: "==2.18.4",
+          requirement: nil,
+          groups: [],
+          file: file_name,
+          source: { tag: version }
+        }],
+        package_manager: "docker"
+      )
+    end
+    let(:updated_dependency_instance) do
+      Dependabot::Dependency.new(
+        name: dependency_name,
+        version: updated_version,
+        previous_version: version,
+        requirements: [{
+          requirement: nil,
+          groups: [],
+          file: file_name,
+          source: { tag: updated_version }
+        }],
+        previous_requirements: [{
+          requirement: nil,
+          groups: [],
+          file: file_name,
+          source: { tag: version }
+        }],
+        package_manager: "docker"
+      )
+    end
+
+    let(:dependency_name) { "public-image-name-1" }
+    let(:version) { "1.0.7" }
+    let(:updated_version) { "1.10" }
+    let(:pull_request) do
+      {
+        number: 1,
+        head: { ref: "docker-#{dependency_dir[0..-2].sub('/', '-')}-#{branch}-#{dependency_name}-#{version}" },
+        html_url: "https://github.com/#{repo}/pull/1"
+      }
+    end
+
+    let(:file_name) { "public-simple.yml" }
+    let(:fixture_file) { fixture("docker", "pipelines", file_name) }
+
+    context "for concourse module" do
+      let(:project_data) do
+        {
+          "module" => "concourse",
+          "repo" => "Pix4D/test_repo",
+          "branch" => "master",
+          "dependency_dir" => "ci/pipelines/"
+        }
+      end
+
+      it "returns the correct project_path" do
+        allow(self).to receive(:recursive_path).and_return([dependency_dir])
+        allow(self).to receive(:fetch_files_and_commit).and_return([[dependency_file], expected_commit])
+        allow(self).to receive(:fetch_dependencies).and_return([dependency_instance])
+        allow(self).to receive(:checker_up_to_date).and_return(false)
+        allow(self).to receive(:requirements).and_return(":own")
+        allow(self).to receive(:checker_updated_dependencies).and_return([updated_dependency_instance])
+        allow(self).to receive(:create_pr).and_return(pull_request)
+
+        actual = pix4_dependabot("docker", project_data, git_cred, docker_cred)
+        expect(actual).to equal("Success")
+      end
+    end
+
+    context "for docker module" do
+      let(:project_data) do
+        {
+          "module" => "docker",
+          "repo" => "Pix4D/test_repo",
+          "branch" => "staging",
+          "dependency_dir" => "dockerfiles/"
+        }
+      end
+      let(:github_sha) { "76abc" }
+      let(:url1) { github_url + "repos/#{repo}/branches/#{branch}" }
+      let(:url2) do
+        github_url +
+          "repos/#{repo}/git/trees/#{github_sha}?recursive=true"
+      end
+      before do
+        stub_request(:get, url1).
+          to_return(
+            status: 200,
+            body: { "name": branch, "commit": { "sha": github_sha } }.to_json,
+            headers: { "content-type" => "application/json" }
+          )
+        stub_request(:get, url2).
+          to_return(
+            status: 200,
+            body: { "sha": github_sha, "tree": [
+              { "path": "dockerfiles/folder-1/Dockerfile" }
+            ] }.to_json,
+            headers: { "content-type" => "application/json" }
+          )
+      end
+
+      it "when directory tree for staging branch is wanted" do
+        allow(self).to receive(:fetch_files_and_commit).and_return([[dependency_file], expected_commit])
+        allow(self).to receive(:fetch_dependencies).and_return([dependency_instance])
+        allow(self).to receive(:checker_up_to_date).and_return(false)
+        allow(self).to receive(:requirements).and_return(":own")
+        allow(self).to receive(:checker_updated_dependencies).and_return([updated_dependency_instance])
+        allow(self).to receive(:create_pr).and_return(pull_request)
+        allow(self).to receive(:auto_merge).and_return("")
+
+        actual = pix4_dependabot("docker", project_data, fake_token, docker_cred)
+        expect(actual).to equal("Success")
+      end
+    end
+  end
+
+  describe "using Python package manager" do
+    let(:dependency_instance) do
+      Dependabot::Dependency.new(
+        name: dependency_name,
+        version: version,
+        requirements: [{
+          requirement: "==#{version}",
           groups: ["dependencies"],
           file: file_name,
           source: nil
@@ -214,16 +178,16 @@ RSpec.describe "describe pix4_dependabot function", :pix4d do
     let(:updated_dependency_instance) do
       Dependabot::Dependency.new(
         name: dependency_name,
-        version: "2.25.1",
-        previous_version: "2.18.4",
+        version: updated_version,
+        previous_version: version,
         requirements: [{
-          requirement: "==2.25.1",
+          requirement: "==#{updated_version}",
           groups: ["dependencies"],
           file: file_name,
           source: nil
         }],
         previous_requirements: [{
-          requirement: "==2.18.4",
+          requirement: "==#{version}",
           groups: ["dependencies"],
           file: file_name,
           source: nil
@@ -231,17 +195,101 @@ RSpec.describe "describe pix4_dependabot function", :pix4d do
         package_manager: "pip"
       )
     end
-    it "returns the correct project_path" do
-      allow(self).to receive(:recursive_path).and_return([dependency_dir])
-      allow(self).to receive(:fetch_files_and_commit).and_return([[dependency_file], expected_commit])
-      allow(self).to receive(:fetch_dependencies).and_return([dependency_instance])
-      allow(self).to receive(:checker_up_to_date).and_return(false)
-      allow(self).to receive(:requirements).and_return(":own")
-      allow(self).to receive(:checker_updated_dependencies).and_return([updated_dependency_instance])
-      allow(self).to receive(:create_pr).and_return(pull_request)
+    let(:project_data) do
+      {
+        "module" => "pip",
+        "repo" => "Pix4D/test_repo",
+        "branch" => "master",
+        "dependency_dir" => "requirement"
+      }
+    end
+    let(:pull_request) do
+      {
+        number: 1,
+        head: { ref: "python-#{dependency_dir.sub('/', '-')}-#{branch}-#{dependency_name}-#{version}" },
+        html_url: "https://github.com/#{repo}/pull/1"
+      }
+    end
+    let(:file_name) { "base_requirements.txt" }
+    let(:fixture_file) { fixture("python", "requirements", file_name) }
 
-      actual = pix4_dependabot("pip", project_data, git_cred, artifactory_cred)
-      expect(actual).to equal("Success")
+    context "for a single dependency" do
+      let(:dependency_name) { "requests" }
+      let(:version) { "2.18.4" }
+      let(:updated_version) { "2.25.1" }
+      it "returns the correct project_path" do
+        allow(self).to receive(:recursive_path).and_return([dependency_dir])
+        allow(self).to receive(:fetch_files_and_commit).and_return([[dependency_file], expected_commit])
+        allow(self).to receive(:fetch_dependencies).and_return([dependency_instance])
+        allow(self).to receive(:checker_up_to_date).and_return(false)
+        allow(self).to receive(:requirements).and_return(":own")
+        allow(self).to receive(:checker_updated_dependencies).and_return([updated_dependency_instance])
+        allow(self).to receive(:create_pr).and_return(pull_request)
+
+        actual = pix4_dependabot("pip", project_data, git_cred, artifactory_cred)
+        expect(actual).to equal("Success")
+      end
+    end
+
+    context "for multiple dependencies" do
+      let(:file_name) { "multi_dependencies.txt" }
+      let(:file_name2) { "multi_dependencies_update.txt" }
+      let(:dependency_file2) do
+        Dependabot::DependencyFile.new(name: file_name2, content: fixture_file, directory: dependency_dir)
+      end
+      let(:dependency_name) { "requests" }
+      let(:version) { "2.18.4" }
+      let(:updated_version) { "2.25.1" }
+      let(:dependency_name2) { "luigi" }
+      let(:version2) { "1.2.0" }
+      let(:updated_version2) { "1.5.4" }
+      let(:dependency_instance2) do
+        Dependabot::Dependency.new(
+          name: dependency_name2,
+          version: version2,
+          requirements: [{
+            requirement: "==#{version2}",
+            groups: ["dependencies"],
+            file: file_name,
+            source: nil
+          }],
+          package_manager: "pip"
+        )
+      end
+      let(:updated_dependency_instance2) do
+        Dependabot::Dependency.new(
+          name: dependency_name2,
+          version: updated_version2,
+          previous_version: version2,
+          requirements: [{
+            requirement: "==#{updated_version2}",
+            groups: ["dependencies"],
+            file: file_name,
+            source: nil
+          }],
+          previous_requirements: [{
+            requirement: "==#{version2}",
+            groups: ["dependencies"],
+            file: file_name,
+            source: nil
+          }],
+          package_manager: "pip"
+        )
+      end
+      it "returns the correct project_path" do
+        allow(self).to receive(:recursive_path).and_return([dependency_dir])
+        allow(self).to receive(:fetch_files_and_commit).and_return([[dependency_file], expected_commit],
+                                                                   [[dependency_file2], expected_commit])
+        allow(self).to receive(:fetch_dependencies).and_return([dependency_instance, dependency_instance2])
+        allow(self).to receive(:checker_up_to_date).and_return(false, false)
+        allow(self).to receive(:requirements).and_return(":own", ":own")
+        allow(self).to receive(:checker_updated_dependencies).and_return([updated_dependency_instance],
+                                                                         [updated_dependency_instance2])
+        allow(self).to receive(:create_pr).and_return(pull_request)
+
+        actual = pix4_dependabot("pip", project_data, git_cred, artifactory_cred)
+        expect(actual).to equal("Success")
+      end
     end
   end
 end

--- a/python/spec/fixtures/requirements/multi_dependencies.txt
+++ b/python/spec/fixtures/requirements/multi_dependencies.txt
@@ -1,0 +1,2 @@
+requests==2.18.4
+luigi==1.2.0

--- a/python/spec/fixtures/requirements/multi_dependencies_update.txt
+++ b/python/spec/fixtures/requirements/multi_dependencies_update.txt
@@ -1,0 +1,2 @@
+requests==2.25.1
+luigi==1.2.0


### PR DESCRIPTION
- if multiple dependencies are updated in a single file, 1 PR will be created
- this is requirement for updating Pipfile and Pipefile.lock in single go, to avoid merge conflicts and wrong lockfiles (sha256 of the Pipfile would be wrong)
- by construction, this will allow also a single PR when updating Concourse template files, hence significantly reducing number of PRs opened by Dependabot
- allows for easier merging and testing of the created PRs

