### PR TITLE
PCI-1809 Fix the CRYPTOGRAPHY/RUST issue

### DIFF
--- a/Dockerfile.pix4d
+++ b/Dockerfile.pix4d
@@ -1,5 +1,7 @@
 FROM ubuntu:18.04 as build
 
+ARG PYTHON_VERSIONS="2.7.18 3.6.13 3.7.10 3.8.8 3.9.2"
+
 LABEL "maintainer"="platform_ci_team@pix4d.com"
 LABEL "description"="Pix4D Dependabot for updating your dependencies."
 
@@ -48,10 +50,9 @@ RUN apt-get update && apt-get install -y software-properties-common \
 ENV PYENV_ROOT=/usr/local/.pyenv \
   PATH="/usr/local/.pyenv/bin:$PATH"
 RUN git clone https://github.com/pyenv/pyenv.git /usr/local/.pyenv \
-  && cd /usr/local/.pyenv && git checkout 9ee109b66148bc39a685926050b7b56cb4bb184b && cd - \
-  && pyenv install 3.9.2 \
-  && pyenv install 2.7.18 \
-  && pyenv global 3.9.2
+  && cd /usr/local/.pyenv && git checkout 9ee109b66148bc39a685926050b7b56cb4bb184b && cd -
+
+RUN for ver in $PYTHON_VERSIONS; do pyenv install $ver; done && pyenv global 3.9.2
 
 ENV BUNDLE_PATH="/home/dependabot/.bundle" \
   BUNDLE_BIN=".bundle/binstubs" \

--- a/Dockerfile.pix4d
+++ b/Dockerfile.pix4d
@@ -52,7 +52,7 @@ ENV PYENV_ROOT=/usr/local/.pyenv \
 RUN git clone https://github.com/pyenv/pyenv.git /usr/local/.pyenv \
   && cd /usr/local/.pyenv && git checkout 9ee109b66148bc39a685926050b7b56cb4bb184b && cd -
 
-RUN for ver in $PYTHON_VERSIONS; do pyenv install $ver; done && pyenv global 3.9.2
+RUN for ver in $PYTHON_VERSIONS; do pyenv install $ver; done && pyenv global ${PYTHON_VERSIONS##* }
 
 ENV BUNDLE_PATH="/home/dependabot/.bundle" \
   BUNDLE_BIN=".bundle/binstubs" \

--- a/python/helpers/build
+++ b/python/helpers/build
@@ -12,9 +12,13 @@ helpers_dir="$(dirname "${BASH_SOURCE[0]}")"
 cp -r \
   "$helpers_dir/lib" \
   "$helpers_dir/run.py" \
+  "$helpers_dir/requirements_py2.txt" \
   "$helpers_dir/requirements.txt" \
   "$install_dir"
 
 cd "$install_dir"
-PYENV_VERSION=2.7.18 pyenv exec pip install -r "requirements.txt"
-PYENV_VERSION=3.9.2  pyenv exec pip install -r "requirements.txt"
+PYENV_VERSION=2.7.18 pyenv exec pip install -r "requirements_py2.txt"
+PYENV_VERSION=3.6.13  CRYPTOGRAPHY_DONT_BUILD_RUST=1 pyenv exec pip install -r "requirements.txt"
+PYENV_VERSION=3.7.10  pyenv exec pip install -r "requirements.txt"
+PYENV_VERSION=3.8.8   pyenv exec pip install -r "requirements.txt"
+PYENV_VERSION=3.9.2   pyenv exec pip install -r "requirements.txt"

--- a/python/helpers/build
+++ b/python/helpers/build
@@ -17,7 +17,9 @@ cp -r \
   "$install_dir"
 
 cd "$install_dir"
+# With PYENV_VERSION=2.7.18 we use different requirements because pip>21.0.0 do not support Python2 anymore
 PYENV_VERSION=2.7.18 pyenv exec pip install -r "requirements_py2.txt"
+# CRYPTOGRAPHY_DONT_BUILD_RUST=1 is used to avoid the need for a Rust compiler while installing cryptography subdependency
 PYENV_VERSION=3.6.13  CRYPTOGRAPHY_DONT_BUILD_RUST=1 pyenv exec pip install -r "requirements.txt"
 PYENV_VERSION=3.7.10  pyenv exec pip install -r "requirements.txt"
 PYENV_VERSION=3.8.8   pyenv exec pip install -r "requirements.txt"

--- a/python/helpers/requirements_py2.txt
+++ b/python/helpers/requirements_py2.txt
@@ -1,10 +1,10 @@
-pip==21.0.1
-pip-tools==6.0.1
+pip==20.3.3
+pip-tools==5.5.0
 flake8==3.9.0
 hashin==0.15.0
 pipenv==2020.11.15
 pipfile==0.0.2
-poetry==1.1.5
+poetry==1.1.4
 wheel==0.36.2
 
 # Some dependencies will only install if Cython is present


### PR DESCRIPTION
- install all most used python versions in Docker image, instead of installing it each day. Across all repositories, almost all these Python versions are used already (except python2 of course) 
- separate requirements files for Python2 and Python3
- this enable upgrading pip, pip-tools and pipenv to versions that do not support Python2 anymore

The Python 2 version is hardcoded in Dependabot code and not installing it causes issues in long term even if it is not actually used :(

Fixing the [current issue](https://builder.ci.pix4d.com/teams/main/pipelines/github-automation-master/jobs/python-updater/builds/9#L60533f78:316) can be simple as this: https://github.com/Pix4D/terraform-tomato/compare/PCI-1809-fix-python-issues-simple but I would still prefer to go with this PR to use latest versions of pipenv and pip and not need to install all this Python versions from Dependabot code EACH DAY.
