### PR TITLE
Pci 1809 support lockfile only updates

### DIFF
--- a/pix4d-dependabot/lib/helpers/helper_dependabot.rb
+++ b/pix4d-dependabot/lib/helpers/helper_dependabot.rb
@@ -26,6 +26,8 @@ def create_pr(package_manager, source, commit, updated_deps, updated_files, cred
 end
 # rubocop:enable Metrics/ParameterLists
 
+# READ this: https://github.com/dependabot/dependabot-core/issues/600#issuecomment-407808103
+# to understand why we need requirements_to_unlock and possible options
 def requirements(lockfile_only, checker)
   requirements =
     if lockfile_only || !checker.requirements_unlocked_or_can_be?

--- a/pix4d-dependabot/pix4d-dependabot.rb
+++ b/pix4d-dependabot/pix4d-dependabot.rb
@@ -10,6 +10,8 @@ require "yaml"
 #   - repo i.e. Pix4D/test-dependabot-python
 #   - branch i.e master
 #   - dependency_dir i.e. /, ci/docker, ci/pipelines, project/requirements
+#   - lockfile_only i.e. Update only lockfiles. Defaults to true in case of Pip module
+#     and false in case of Docker module
 
 # REQUIRED DEPENDING ON MODULE:
 

--- a/pix4d-dependabot/pix4d-dependabot.rb
+++ b/pix4d-dependabot/pix4d-dependabot.rb
@@ -25,23 +25,21 @@ require "yaml"
 
 def create_extra_credentials(package_manager)
   if package_manager == "pip"
-    return [
-      {
-        "type" => "python_index",
-        "index-url" => ENV["EXTRA_INDEX_URL"],
-        "token" => "#{ENV['ARTIFACTORY_USERNAME']}:#{ENV['ARTIFACTORY_PASSWORD']}"
-      }
-    ]
+    return {
+      "type" => "python_index",
+      "index-url" => ENV["EXTRA_INDEX_URL"],
+      "token" => "#{ENV['ARTIFACTORY_USERNAME']}:#{ENV['ARTIFACTORY_PASSWORD']}"
+    }
   end
 
   return unless package_manager == "docker"
 
-  [{
+  {
     "type" => "docker_registry",
     "registry" => (ENV["DOCKER_REGISTRY"] || "registry.hub.docker.com"),
     "username" => (ENV["DOCKER_USER"] || nil),
     "password" => (ENV["DOCKER_PASS"] || nil)
-  }]
+  }
 end
 
 def main
@@ -72,9 +70,9 @@ def main
                       else
                         project_data["module"]
                       end
-    extra_credentials = create_extra_credentials(package_manager)
+    credentials = [credentials_github, create_extra_credentials(package_manager)]
 
-    pix4_dependabot(package_manager, project_data, credentials_github, extra_credentials)
+    pix4_dependabot(package_manager, project_data, credentials)
   end
 end
 

--- a/pix4d-dependabot/spec/helpers/helper_dependabot_spec.rb
+++ b/pix4d-dependabot/spec/helpers/helper_dependabot_spec.rb
@@ -98,7 +98,8 @@ RSpec.describe "describe pix4_dependabot function", :pix4d do
           "module" => "concourse",
           "repo" => "Pix4D/test_repo",
           "branch" => "master",
-          "dependency_dir" => "ci/pipelines/"
+          "dependency_dir" => "ci/pipelines/",
+          "lockfile_only" => false
         }
       end
 
@@ -357,7 +358,7 @@ RSpec.describe "describe dependencies_updater function", :pix4d do
         [updated_dependency(dependency_name1, updated_version1, version1, "Pipfile")],
         [updated_dependency(dependency_name2, updated_version2, version2, "Pipfile")]
       )
-      updated_files, = dependencies_updater("pip", files, dependencies, [{}])
+      updated_files, = dependencies_updater("pip", false, files, dependencies, [{}])
 
       expect(updated_files[0].name).to eq(expected_files[0].name)
       expect(updated_files[0].content).to eq(expected_files[0].content)

--- a/pix4d-dependabot/spec/helpers/helper_dependabot_spec.rb
+++ b/pix4d-dependabot/spec/helpers/helper_dependabot_spec.rb
@@ -34,6 +34,8 @@ RSpec.describe "describe pix4_dependabot function", :pix4d do
       "password" => nil
     }
   end
+  let(:credentials_docker) { [git_cred, docker_cred] }
+  let(:credentials_pip) { [git_cred, artifactory_cred] }
   let(:dependency_file) do
     Dependabot::DependencyFile.new(name: file_name, content: fixture_file, directory: dependency_dir)
   end
@@ -109,7 +111,7 @@ RSpec.describe "describe pix4_dependabot function", :pix4d do
         allow(self).to receive(:checker_updated_dependencies).and_return([updated_dependency_instance])
         allow(self).to receive(:create_pr).and_return(pull_request)
 
-        actual = pix4_dependabot("docker", project_data, git_cred, docker_cred)
+        actual = pix4_dependabot("docker", project_data, credentials_docker)
         expect(actual).to equal("Success")
       end
     end
@@ -155,7 +157,7 @@ RSpec.describe "describe pix4_dependabot function", :pix4d do
         allow(self).to receive(:create_pr).and_return(pull_request)
         allow(self).to receive(:auto_merge).and_return("")
 
-        actual = pix4_dependabot("docker", project_data, fake_token, docker_cred)
+        actual = pix4_dependabot("docker", project_data, credentials_docker)
         expect(actual).to equal("Success")
       end
     end
@@ -226,7 +228,7 @@ RSpec.describe "describe pix4_dependabot function", :pix4d do
         allow(self).to receive(:checker_updated_dependencies).and_return([updated_dependency_instance])
         allow(self).to receive(:create_pr).and_return(pull_request)
 
-        actual = pix4_dependabot("pip", project_data, git_cred, artifactory_cred)
+        actual = pix4_dependabot("pip", project_data, credentials_pip)
         expect(actual).to equal("Success")
       end
     end
@@ -287,7 +289,7 @@ RSpec.describe "describe pix4_dependabot function", :pix4d do
                                                                          [updated_dependency_instance2])
         allow(self).to receive(:create_pr).and_return(pull_request)
 
-        actual = pix4_dependabot("pip", project_data, git_cred, artifactory_cred)
+        actual = pix4_dependabot("pip", project_data, credentials_pip)
         expect(actual).to equal("Success")
       end
     end
@@ -355,7 +357,7 @@ RSpec.describe "describe dependencies_updater function", :pix4d do
         [updated_dependency(dependency_name1, updated_version1, version1, "Pipfile")],
         [updated_dependency(dependency_name2, updated_version2, version2, "Pipfile")]
       )
-      updated_files, = dependencies_updater("pip", files, dependencies, {}, {})
+      updated_files, = dependencies_updater("pip", files, dependencies, [{}])
 
       expect(updated_files[0].name).to eq(expected_files[0].name)
       expect(updated_files[0].content).to eq(expected_files[0].content)

--- a/pix4d-dependabot/spec/helpers/helper_dependabot_spec.rb
+++ b/pix4d-dependabot/spec/helpers/helper_dependabot_spec.rb
@@ -367,3 +367,30 @@ RSpec.describe "describe dependencies_updater function", :pix4d do
     end
   end
 end
+
+RSpec.describe "describe lockfile_only_defaults function", :pix4d do
+  it "raises TypeError" do
+    expect do
+      lockfile_only_defaults("any",
+                             { "lockfile_only" => "wrong" })
+    end .to raise_error(TypeError, "lockfile_only key should be boolean type")
+  end
+  context "for any module" do
+    let(:package_manager) { "docker" }
+    it "returns correct default value" do
+      expect(lockfile_only_defaults(package_manager, {})).to be false
+    end
+    it "correctly replaces default value" do
+      expect(lockfile_only_defaults(package_manager, { "module" => "docker", "lockfile_only" => true })).to be true
+    end
+  end
+  context "for pip module" do
+    let(:package_manager) { "pip" }
+    it "returns correct default value" do
+      expect(lockfile_only_defaults(package_manager, { "module" => "pip" })).to be true
+    end
+    it "correctly replaces default value" do
+      expect(lockfile_only_defaults(package_manager, { "module" => "pip", "lockfile_only" => false })).to be false
+    end
+  end
+end


### PR DESCRIPTION
- refactor/simplify credentials handling
- enable setting `lockfile-only` option
- set the default `lockfile_only` values in case option is not set in `REPOSITORY_DATA` environmental variable

What is the `lockfile-only` option? Best to look at the PR examples: 
1) when the option is set to true, Pipfile is never updated, only Pipfile.lock can change
https://github.com/Pix4D/github-automation-playground/pull/114
This option is preferred by cloud team @jamesdynes 
2) when the option is set to false, dependencies in both files are changed, even the pinned ones if a new version exists
https://github.com/Pix4D/github-automation-playground/pull/115
The default behavior is set to `true` for Python (pip) module only, while in all other cases we keep the default Dependabot behavior (`false`). 
The PR in tomato will follow shortly.

In short: 
- pip module default `lockfile-only` option is set to true
- all other modules (i.e. docker) default `lockfile-only` option is set to false, keeping the same behavior as we have now 
- for each repository we can set this option `lockfile-only` in `terraform tomato` (github-automatio-pipeline). The set value will overwrite default value set here for that repo.