### PR TITLE
PCI-1839 Ensure working directory always starts with `/`

### DIFF
--- a/pix4d-dependabot/lib/helpers/helper_dependabot.rb
+++ b/pix4d-dependabot/lib/helpers/helper_dependabot.rb
@@ -133,7 +133,7 @@ def pix4_dependabot(package_manager, project_data, credentials)
 
   input_files_path = recursive_path(project_data, github_cred)
 
-  print "Working in #{project_data['repo']}\n"
+  print "Working in #{project_data['repo']} on #{project_data['branch']}\n"
   input_files_path.each do |file_path|
     print "  - Checking the files in #{file_path}\n"
     source = source_init(file_path, project_data)

--- a/pix4d-dependabot/lib/helpers/path_level.rb
+++ b/pix4d-dependabot/lib/helpers/path_level.rb
@@ -8,6 +8,15 @@ def select_path_per_directory(git_tree, directory)
   files.map { |item| item["path"] }
 end
 
+def normalize_path(path)
+  return path if path == "/"
+
+  path = path.delete_suffix("/")
+  return path if path.start_with?("/")
+
+  path.prepend("/")
+end
+
 def recursive_path(project_data, github_token)
   if project_data["module"] == "docker"
     selected_paths = []
@@ -26,6 +35,14 @@ def recursive_path(project_data, github_token)
       input_files_path << path
     end
   else
-    input_files_path = project_data["dependency_dirs"]
+    input_files_path = []
+    # normalize the path first because pip module fails if there is no '/'
+    # at the beginning of dependency_dirs paths ["/path_1/", "/path_2"]`
+    project_data["dependency_dirs"].each do |path|
+      input_files_path << normalize_path(path)
+    end
+    raise StandardError unless project_data["dependency_dirs"].length == input_files_path.length
+
+    input_files_path
   end
 end

--- a/pix4d-dependabot/spec/helpers/path_level_spec.rb
+++ b/pix4d-dependabot/spec/helpers/path_level_spec.rb
@@ -8,16 +8,33 @@ RSpec.describe "recursive_path", :pix4d do
     it "returns the correct project_path" do
       project_data = {
         "module" => "concourse",
-        "dependency_dirs" => ["ci/pipelines"]
+        "dependency_dirs" => ["ci/pipelines/"]
       }
-      expect(recursive_path(project_data, "token")).to eq(["ci/pipelines"])
+      expect(recursive_path(project_data, "token")).to eq(["/ci/pipelines"])
     end
     it "returns the correct project_path for multiple directories" do
       project_data = {
         "module" => "concourse",
-        "dependency_dirs" => ["ci/pipelines", "extra_pipelines/"]
+        "dependency_dirs" => ["ci/pipelines", "/extra_pipelines/"]
       }
-      expect(recursive_path(project_data, "token")).to eq(["ci/pipelines", "extra_pipelines/"])
+      expect(recursive_path(project_data, "token")).to eq(["/ci/pipelines", "/extra_pipelines"])
+    end
+  end
+
+  context "using a python/pip feature_package" do
+    it "returns the correct project_path" do
+      project_data = {
+        "module" => "pip",
+        "dependency_dirs" => ["/"]
+      }
+      expect(recursive_path(project_data, "token")).to eq(["/"])
+    end
+    it "returns the correct project_path for multiple directories" do
+      project_data = {
+        "module" => "pip",
+        "dependency_dirs" => ["/python_package_1", "python_package_2/"]
+      }
+      expect(recursive_path(project_data, "token")).to eq(["/python_package_1", "/python_package_2"])
     end
   end
 


### PR DESCRIPTION
- ensure that the working directory always starts with `/`. It is not important at all for docker and concourse package managers, but it is for Python/pip one for some reason, unrelated to Pix4D code.

No matter the input format (i.e `["/", "/path_1/", "/path_2", "path_3/", "path_4/"]`) we always want the output to be `["/", "/path_1", "/path_2", "/path_3", "/path_4"]`