### PR TITLE
Update pre-packaged older python3 to latest release

### DIFF
--- a/Dockerfile.pix4d
+++ b/Dockerfile.pix4d
@@ -1,6 +1,6 @@
 FROM ubuntu:18.04 as build
 
-ARG PYTHON_VERSIONS="3.6.13 3.7.10 3.8.8 3.9.6"
+ARG PYTHON_VERSIONS="3.6.14 3.7.11 3.8.11 3.9.6"
 
 LABEL "maintainer"="platform_ci_team@pix4d.com"
 LABEL "description"="Pix4D Dependabot for updating your dependencies."

--- a/python/helpers/build
+++ b/python/helpers/build
@@ -17,9 +17,9 @@ cp -r \
 
 cd "$install_dir"
 # CRYPTOGRAPHY_DONT_BUILD_RUST=1 is used to avoid the need for a Rust compiler while installing cryptography subdependency
-PYENV_VERSION=3.6.13  CRYPTOGRAPHY_DONT_BUILD_RUST=1 pyenv exec pip install -r "requirements.txt"
-PYENV_VERSION=3.7.10  pyenv exec pip install -r "requirements.txt"
-PYENV_VERSION=3.8.8  pyenv exec pip install -r "requirements.txt"
+PYENV_VERSION=3.6.14  CRYPTOGRAPHY_DONT_BUILD_RUST=1 pyenv exec pip install -r "requirements.txt"
+PYENV_VERSION=3.7.11  pyenv exec pip install -r "requirements.txt"
+PYENV_VERSION=3.8.11  pyenv exec pip install -r "requirements.txt"
 PYENV_VERSION=3.9.6  pyenv exec pip install -r "requirements.txt"
 
 # Workaround of https://github.com/python-poetry/poetry/issues/3010


### PR DESCRIPTION
This fixes an issue when trying to update dependencies of a project using python 3.6 (no patch level specified) as pyenv is now installing the latest 3.6.14 which comes with pip 18 which will choke on trying to handle the `cryptography` module that requires rust to build from source and which is required by the dependabot python helpers. By updating the version it will not need to install it and will gain the newer pip version that is already installed when building the docker image.

https://builder.ci.pix4d.com/teams/developers/pipelines/dependabot-fish_fix_dependabot_image_to_use_latest_python_releases