### PR TITLE
fly_helper: ci/settings: always set the Concourse team name

### DIFF
--- a/ci/settings/feature-branch.yml
+++ b/ci/settings/feature-branch.yml
@@ -5,3 +5,4 @@ pr_bot_triggered_jobs:
   - build-test-deploy-dependabot
 disable_on_feature: true
 docker_tag_add_file:
+team: developers


### PR DESCRIPTION

Context:

`fly_helper` currently doesn't enforce the presence of the Concourse team name in the `ci/settings` file.
If the team is missing, `fly_helper` will use the default `developers`. This works fine as long as the pipeline belongs to the `developers` team, but caused many difficult to understand errors for other Concourse teams, for example `cloud`.
To avoid such errors, we will soon make `fly_helper` refuse to proceed if the team is missing (ticket: https://pix4dbug.atlassian.net/browse/PCI-2073).

In preparation, we are proactively updating all pipelines running on Concourse to contain the team name, so that the switch to the new version of `fly_helper` should not require additional changes to the settings file.

For each pipeline, we used as value for the Concourse team what is declared in https://github.com/Pix4D/ci-pipelines/blob/master/pipelines.yml.

What you as a reviewer should do:

1. Double-check that the Concourse team name is correct.
2. Once this PR is merged, NEVER use the `-target` to `fly_helper`. It is not needed and just causes pain and confusion. And it will go away soon.
3. Help us by proactively adding the Concourse team to any of your repositories that use Concourse but that for any reason are not present in https://github.com/Pix4D/ci-pipelines/blob/master/pipelines.yml
4. Since each approval causes a GitHub notification, please approve with the minimum number of required approvals.

If you have questions, please ask on `platform-ci-helps-you`, so that the answers can be shared also with other Pix4Ders.

Thanks!


**Dears Reviewers**: appreciate to ensure the PR is approved by the minimum number of required approvals